### PR TITLE
fix: extract actual Number from season object

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Scanner/Scraper.cs
+++ b/Jellyfin.Plugin.Newsletters/Scanner/Scraper.cs
@@ -320,7 +320,7 @@ public class Scraper
                     logger.Debug("Parsing Season Number");
                     try
                     {
-                        currFileObj.Season = int.Parse(season.Name.Split(' ')[1], CultureInfo.CurrentCulture);
+                        currFileObj.Season = int.Parse(season.Number, CultureInfo.CurrentCulture);
                     }
                     catch (Exception e)
                     {


### PR DESCRIPTION
parsing the name is error prone because seasons could be named in jellyfin