### PR TITLE
Fix for querying with title in newsletter.db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.0.2
+- Bug fix for querying title in the newsletter.db.
+
 # 0.9.0.1
 - Bug fix for community rating parsing.
 - Bug fix for parsing runtime.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>0.9.0.1</Version>
-        <AssemblyVersion>0.9.0.1</AssemblyVersion>
-        <FileVersion>0.9.0.1</FileVersion>
+        <Version>0.9.0.2</Version>
+        <AssemblyVersion>0.9.0.2</AssemblyVersion>
+        <FileVersion>0.9.0.2</FileVersion>
     </PropertyGroup>
 </Project>

--- a/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
@@ -45,7 +45,7 @@ public class ClientBuilder(Logger loggerInstance,
         List<NlDetailsJson> compiledList = new List<NlDetailsJson>();
         List<NlDetailsJson> finalList = new List<NlDetailsJson>();
 
-        foreach (var row in Db.Query("SELECT * FROM CurrNewsletterData WHERE Title='" + currObj.Title + "';"))
+        foreach (var row in Db.Query("SELECT * FROM CurrNewsletterData WHERE Title='" + currObj.Title.Replace("'", "''", StringComparison.Ordinal) + "';"))
         {
             if (row is not null)
             {

--- a/Jellyfin.Plugin.Newsletters/Jellyfin.Plugin.Newsletters.csproj
+++ b/Jellyfin.Plugin.Newsletters/Jellyfin.Plugin.Newsletters.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.9.0" />
-    <PackageReference Include="Jellyfin.Model" Version="10.9.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.10.0" />
+    <PackageReference Include="Jellyfin.Model" Version="10.10.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="SQLitePCL.pretty.netstandard" Version="3.1.0" />

--- a/Jellyfin.Plugin.Newsletters/manifest.json
+++ b/Jellyfin.Plugin.Newsletters/manifest.json
@@ -9,6 +9,14 @@
         "imageUrl": "https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/logo.png",
         "versions": [
             {
+                "version": "0.9.0.2",
+                "changelog": "- Bug fix for querying title in the newsletter.db. FULL CHANGELOG: https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/CHANGELOG.md\n",
+                "targetAbi": "10.10.0.0",
+                "sourceUrl": "https://github.com/Sanidhya30/Jellyfin-Newsletter/releases/download/v0.9.0.2/newsletters_0.9.0.2.zip",
+                "checksum": "0904332ca0bb03d1066e19f9777fbd9d",
+                "timestamp": "2025-08-21T07:48:57Z"
+            },
+            {
                 "version": "0.9.0.1",
                 "changelog": "- Bug fix for community rating parsing. - Bug fix for parsing runtime. FULL CHANGELOG: https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/CHANGELOG.md\n",
                 "targetAbi": "10.10.0.0",

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 name: "Newsletters"
 guid: "60f478ab-2dd6-4ea0-af10-04d033f75979"
 imageUrl: "https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/logo.png"
-version: "0.9.0.1"
+version: "0.9.0.2"
 targetAbi: "10.10.0.0"
 framework: "net8.0"
 overview: "Send newsletters for recently added media"
@@ -14,6 +14,5 @@ artifacts:
   - "SQLitePCL.pretty.dll"
   - "SixLabors.ImageSharp.dll"
 changelog: >
-  - Bug fix for community rating parsing.
-  - Bug fix for parsing runtime.
+  - Bug fix for querying title in the newsletter.db.
   FULL CHANGELOG: https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/CHANGELOG.md

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,14 @@
         "imageUrl": "https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/logo.png",
         "versions": [
             {
+                "version": "0.9.0.2",
+                "changelog": "- Bug fix for querying title in the newsletter.db. FULL CHANGELOG: https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/CHANGELOG.md\n",
+                "targetAbi": "10.10.0.0",
+                "sourceUrl": "https://github.com/Sanidhya30/Jellyfin-Newsletter/releases/download/v0.9.0.2/newsletters_0.9.0.2.zip",
+                "checksum": "0904332ca0bb03d1066e19f9777fbd9d",
+                "timestamp": "2025-08-21T07:48:57Z"
+            },
+            {
                 "version": "0.9.0.1",
                 "changelog": "- Bug fix for community rating parsing. - Bug fix for parsing runtime. FULL CHANGELOG: https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/CHANGELOG.md\n",
                 "targetAbi": "10.10.0.0",


### PR DESCRIPTION
This PR contains the following changes:

- Fix for querying title in the newsletter.db. Previously I had change the sanitization of items in db to get the proper poster path whenever required, missed out this to change.