### PR TITLE
Header templates for HTML clients

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Clients/Email/HTMLBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Email/HTMLBuilder.cs
@@ -216,28 +216,6 @@ public class HtmlBuilder(
     }
 
     /// <inheritdoc/>
-    protected override string GetEventSectionHeader(string eventType, string libraryName = "Library")
-    {
-        var (title, emoji, color) = eventType.ToLowerInvariant() switch
-        {
-            "add" => ($"Added to {libraryName}", "🎬", "#4CAF50"),
-            "update" => ($"Updated in {libraryName}", "🔄", "#2196F3"),
-            "delete" => ($"Removed from {libraryName}", "🗑️", "#F44336"),
-            "upcoming" => ($"Upcoming in {libraryName}", "📅", "#FF8C00"),
-            _ => ($"Added to {libraryName}", "🎬", "#4CAF50")
-        };
-
-        return $@"
-        <tr>
-            <td colspan='2' style='padding: 20px 10px 10px 10px;'>
-                <h2 style='color: {color}; margin: 0; font-size: 1.8em; border-bottom: 2px solid {color}; padding-bottom: 10px; display: flex; align-items: center; gap: 8px;'>
-                   <span style='margin-right: 4px;'>{emoji}</span> {title}
-                </h2>
-            </td>
-        </tr>";
-    }
-
-    /// <inheritdoc/>
     protected override string GetEventBadge(string eventType)
     {
         var (label, emoji, bgColor) = eventType.ToLowerInvariant() switch

--- a/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using Jellyfin.Plugin.Newsletters.Configuration;
 using Jellyfin.Plugin.Newsletters.Integrations;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
@@ -30,6 +31,10 @@ public abstract class HtmlContentBuilder(
 {
     private string bodyHtml = string.Empty;
     private string entryHtml = string.Empty;
+    private string headerAddHtml = string.Empty;
+    private string headerUpdateHtml = string.Empty;
+    private string headerDeleteHtml = string.Empty;
+    private string headerUpcomingHtml = string.Empty;
     private bool _isSetup;
 
     /// <summary>
@@ -44,12 +49,30 @@ public abstract class HtmlContentBuilder(
 
     /// <summary>
     /// Gets the HTML section header for an event type and library name.
-    /// Each client provides its own markup style.
+    /// Loads the header from the parsed template and substitutes {LibraryName}.
     /// </summary>
     /// <param name="eventType">The event type (add, update, delete, upcoming).</param>
     /// <param name="libraryName">The library name to display.</param>
     /// <returns>An HTML string for the section header.</returns>
-    protected abstract string GetEventSectionHeader(string eventType, string libraryName = "Library");
+    protected virtual string GetEventSectionHeader(string eventType, string libraryName = "Library")
+    {
+        string headerTemplate = eventType.ToLowerInvariant() switch
+        {
+            "add" => headerAddHtml,
+            "update" => headerUpdateHtml,
+            "delete" => headerDeleteHtml,
+            "upcoming" => headerUpcomingHtml,
+            _ => headerAddHtml
+        };
+
+        if (string.IsNullOrWhiteSpace(headerTemplate))
+        {
+            Logger.Warn($"No header template found for event type '{eventType}'. Using empty string.");
+            return string.Empty;
+        }
+
+        return this.TemplateReplace(headerTemplate, "{LibraryName}", libraryName);
+    }
 
     /// <summary>
     /// Gets the HTML badge for an event type to be displayed on individual entries.
@@ -198,6 +221,13 @@ public abstract class HtmlContentBuilder(
         var replaceDict = item.GetReplaceDict();
         CustomizeItemReplaceDict(item, eventType, replaceDict);
 
+        // Add computed replacements to the dict
+        replaceDict["{EventBadge}"] = GetEventBadge(eventType);
+        replaceDict["{SeasonEpsInfo}"] = seaEpsHtml;
+        replaceDict["{ItemURL}"] = string.IsNullOrEmpty(Config.Hostname) || eventType == "upcoming" || eventType == "delete"
+            ? string.Empty
+            : $"{Config.Hostname}/web/index.html#/details?id={item.ItemID}&serverId={serverId}&event={eventType}";
+
         foreach (var ele in replaceDict)
         {
             if (ele.Value is not null)
@@ -206,16 +236,7 @@ public abstract class HtmlContentBuilder(
             }
         }
 
-        string eventBadge = GetEventBadge(eventType);
-        tmpEntry = tmpEntry.Replace("{EventBadge}", eventBadge, StringComparison.Ordinal);
-
-        string itemUrl = string.IsNullOrEmpty(Config.Hostname) || eventType == "upcoming" || eventType == "delete"
-            ? string.Empty
-            : $"{Config.Hostname}/web/index.html#/details?id={item.ItemID}&serverId={serverId}&event={eventType}";
-
-        return tmpEntry
-            .Replace("{SeasonEpsInfo}", seaEpsHtml, StringComparison.Ordinal)
-            .Replace("{ItemURL}", itemUrl, StringComparison.Ordinal);
+        return tmpEntry;
     }
 
     /// <summary>
@@ -262,6 +283,13 @@ public abstract class HtmlContentBuilder(
             var replaceDict = item.GetReplaceDict();
             CustomizeTestItemReplaceDict(item, eventType, replaceDict, config);
 
+            // Add computed replacements to the dict
+            replaceDict["{EventBadge}"] = GetEventBadge(eventType);
+            replaceDict["{SeasonEpsInfo}"] = seaEpsHtml;
+            replaceDict["{ItemURL}"] = string.IsNullOrEmpty(Config.Hostname)
+                ? string.Empty
+                : Config.Hostname;
+
             foreach (var ele in replaceDict)
             {
                 if (ele.Value is not null)
@@ -270,17 +298,7 @@ public abstract class HtmlContentBuilder(
                 }
             }
 
-            string eventBadge = GetEventBadge(eventType);
-            tmpEntry = tmpEntry.Replace("{EventBadge}", eventBadge, StringComparison.Ordinal);
-
-            string itemUrl = string.IsNullOrEmpty(Config.Hostname)
-                ? string.Empty
-                : Config.Hostname;
-            string entryHTML = tmpEntry
-                .Replace("{SeasonEpsInfo}", seaEpsHtml, StringComparison.Ordinal)
-                .Replace("{ItemURL}", itemUrl, StringComparison.Ordinal);
-
-            testHTML.Append(entryHTML);
+            testHTML.Append(tmpEntry);
         }
 
         return testHTML.ToString();
@@ -301,10 +319,11 @@ public abstract class HtmlContentBuilder(
 
     private void DefaultBodyAndEntry(ITemplatedConfiguration config)
     {
-        Logger.Debug("Checking for default Body and Entry HTML from Template file..");
+        Logger.Debug("Checking for default Body, Entry, and Header HTML from Template file..");
 
         this.bodyHtml = config.Body ?? string.Empty;
         this.entryHtml = config.Entry ?? string.Empty;
+        string headerHtml = config.Header ?? string.Empty;
 
         try
         {
@@ -346,12 +365,73 @@ public abstract class HtmlContentBuilder(
                     Logger.Error(ex);
                 }
             }
+
+            if (string.IsNullOrWhiteSpace(headerHtml))
+            {
+                try
+                {
+                    headerHtml = File.ReadAllText(Path.Combine(pluginDir, "Templates", category, "template_header.html"));
+                    Logger.Debug($"Header HTML set from Template file ({category}) internally!");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Failed to set default Header HTML from Template file");
+                    Logger.Error(ex);
+                }
+            }
+
+            // Parse the four header sections from the combined template
+            ParseHeaderSections(headerHtml);
         }
         catch (Exception e)
         {
             Logger.Error("Failed to locate/set html body from template file..");
             Logger.Error(e);
         }
+    }
+
+    /// <summary>
+    /// Parses the combined header HTML into four separate sections using template tag IDs.
+    /// Extracts content between &lt;template id="header-{type}"&gt; and &lt;/template&gt; markers.
+    /// </summary>
+    /// <param name="fullHeaderHtml">The combined header HTML containing all four template sections.</param>
+    private void ParseHeaderSections(string fullHeaderHtml)
+    {
+        if (string.IsNullOrWhiteSpace(fullHeaderHtml))
+        {
+            Logger.Warn("Header HTML is empty. Section headers will not be rendered.");
+            return;
+        }
+
+        this.headerAddHtml = ExtractTemplateSection(fullHeaderHtml, "header-add");
+        this.headerUpdateHtml = ExtractTemplateSection(fullHeaderHtml, "header-update");
+        this.headerDeleteHtml = ExtractTemplateSection(fullHeaderHtml, "header-delete");
+        this.headerUpcomingHtml = ExtractTemplateSection(fullHeaderHtml, "header-upcoming");
+
+        Logger.Debug($"Header sections parsed — Add: {!string.IsNullOrEmpty(this.headerAddHtml)}, Update: {!string.IsNullOrEmpty(this.headerUpdateHtml)}, Delete: {!string.IsNullOrEmpty(this.headerDeleteHtml)}, Upcoming: {!string.IsNullOrEmpty(this.headerUpcomingHtml)}");
+    }
+
+    /// <summary>
+    /// Extracts the inner content of a template tag by its ID.
+    /// For example, for id="header-add", extracts content between
+    /// <template id="header-add"> and </template>.
+    /// </summary>
+    /// <param name="html">The full HTML string containing template tags.</param>
+    /// <param name="templateId">The ID of the template tag to extract.</param>
+    /// <returns>The inner content of the matched template tag, or empty string if not found.</returns>
+    private string ExtractTemplateSection(string html, string templateId)
+    {
+        // Match <template id="header-add"> ... </template> (case-insensitive, single-line mode)
+        string pattern = $@"<template\s+id\s*=\s*[""']{Regex.Escape(templateId)}[""']\s*>(.*?)</template>";
+        var match = Regex.Match(html, pattern, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+
+        if (match.Success)
+        {
+            return match.Groups[1].Value.Trim();
+        }
+
+        Logger.Warn($"Template section '{templateId}' not found in header HTML.");
+        return string.Empty;
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixMessageBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixMessageBuilder.cs
@@ -140,21 +140,6 @@ public class MatrixMessageBuilder(
     }
 
     /// <inheritdoc/>
-    protected override string GetEventSectionHeader(string eventType, string libraryName = "Library")
-    {
-        var (title, emoji, color) = eventType.ToLowerInvariant() switch
-        {
-            "add" => ($"Added to {libraryName}", "🎬", "#4CAF50"),
-            "update" => ($"Updated in {libraryName}", "🔄", "#2196F3"),
-            "delete" => ($"Removed from {libraryName}", "🗑️", "#F44336"),
-            "upcoming" => ($"Upcoming in {libraryName}", "📅", "#FF8C00"),
-            _ => ($"Added to {libraryName}", "🎬", "#4CAF50")
-        };
-
-        return $"<h2><font data-mx-color='{color}'>{emoji} {title}</font></h2><hr/>";
-    }
-
-    /// <inheritdoc/>
     protected override string GetEventBadge(string eventType)
     {
         var (label, emoji, bgColor) = eventType.ToLowerInvariant() switch

--- a/Jellyfin.Plugin.Newsletters/Configuration/EmailConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/EmailConfiguration.cs
@@ -69,6 +69,13 @@ public class EmailConfiguration : ITemplatedConfiguration
     public string Entry { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the header HTML template for section headers.
+    /// Uses template tags with IDs (header-add, header-update, header-delete, header-upcoming).
+    /// If empty, the default template file is used.
+    /// </summary>
+    public string Header { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets the template category (e.g., "Modern").
     /// </summary>
     public string TemplateCategory { get; set; } = "Modern";

--- a/Jellyfin.Plugin.Newsletters/Configuration/ITemplatedConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/ITemplatedConfiguration.cs
@@ -20,4 +20,11 @@ public interface ITemplatedConfiguration : INewsletterConfiguration
     /// Gets the template category (e.g., "Modern", "Matrix").
     /// </summary>
     string TemplateCategory { get; }
+
+    /// <summary>
+    /// Gets the custom HTML header template containing section headers for each event type.
+    /// Uses template tags with IDs (header-add, header-update, header-delete, header-upcoming).
+    /// If empty, the default template file is used.
+    /// </summary>
+    string Header { get; }
 }

--- a/Jellyfin.Plugin.Newsletters/Configuration/MatrixConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/MatrixConfiguration.cs
@@ -47,6 +47,13 @@ public class MatrixConfiguration : ITemplatedConfiguration
     /// </summary>
     public string Entry { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Gets or sets the header HTML template for section headers.
+    /// Uses template tags with IDs (header-add, header-update, header-delete, header-upcoming).
+    /// If empty, the default template file is used.
+    /// </summary>
+    public string Header { get; set; } = string.Empty;
+
     /// <inheritdoc/>
     public Collection<string> SelectedSeriesLibraries { get; set; } = new();
 

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -1007,6 +1007,7 @@
                     Subject: 'Jellyfin Newsletter',
                     Body: '',
                     Entry: '',
+                    Header: '',
                     TemplateCategory: 'Modern',
                     SelectedSeriesLibraries: [],
                     SelectedMoviesLibraries: [],
@@ -1061,6 +1062,7 @@
                 config.Subject = document.getElementById('email-subject-' + id).value;
                 config.Body = document.getElementById('email-body-' + id).value;
                 config.Entry = document.getElementById('email-entry-' + id).value;
+                config.Header = document.getElementById('email-header-' + id).value;
                 config.TemplateCategory = document.getElementById('email-category-' + id).value;
                 config.EnableSsl = document.getElementById('email-ssl-' + id).checked;
 
@@ -1163,10 +1165,17 @@
                     html += '    <div class="inputContainer">';
                     html += '      <label class="inputLabel inputLabelUnfocused">Body HTML:</label>';
                     html += '      <textarea id="email-body-' + config.Id + '" style="width: 100%; height: 200px;" onchange="updateEmailConfigFromUI(\'' + config.Id + '\')">' + (config.Body || '') + '</textarea>';
+                    html += '      <div class="fieldDescription">Custom body wrapper template. Leave empty to use the default template.</div>';
                     html += '    </div>';
                     html += '    <div class="inputContainer">';
                     html += '      <label class="inputLabel inputLabelUnfocused">Entry HTML:</label>';
                     html += '      <textarea id="email-entry-' + config.Id + '" style="width: 100%; height: 200px;" onchange="updateEmailConfigFromUI(\'' + config.Id + '\')">' + (config.Entry || '') + '</textarea>';
+                    html += '      <div class="fieldDescription">Custom entry template for each item. Leave empty to use the default template.</div>';
+                    html += '    </div>';
+                    html += '    <div class="inputContainer">';
+                    html += '      <label class="inputLabel inputLabelUnfocused">Header HTML:</label>';
+                    html += '      <textarea id="email-header-' + config.Id + '" style="width: 100%; height: 200px;" onchange="updateEmailConfigFromUI(\'' + config.Id + '\')">' + (config.Header || '') + '</textarea>';
+                    html += '      <div class="fieldDescription">Custom section header template. Uses &lt;template&gt; tags with IDs: header-add, header-update, header-delete, header-upcoming. Placeholder: {LibraryName}. Leave empty to use the default template.</div>';
                     html += '    </div>';
                     html += '  </div>';
                     html += '</div>';
@@ -1187,6 +1196,7 @@
                     TemplateCategory: 'Matrix',
                     Body: '',
                     Entry: '',
+                    Header: '',
                     SelectedSeriesLibraries: [],
                     SelectedMoviesLibraries: [],
                     NewsletterOnItemAddedEnabled: true,
@@ -1232,6 +1242,7 @@
                 config.RoomId = document.getElementById('matrix-room-' + id).value;
                 config.Body = document.getElementById('matrix-body-' + id).value;
                 config.Entry = document.getElementById('matrix-entry-' + id).value;
+                config.Header = document.getElementById('matrix-header-' + id).value;
                 config.TemplateCategory = document.getElementById('matrix-category-' + id).value;
 
                 config.NewsletterOnItemAddedEnabled = document.getElementById('matrix-event-add-' + id).checked;
@@ -1300,10 +1311,17 @@
                     html += '    <div class="inputContainer">';
                     html += '      <label class="inputLabel inputLabelUnfocused">Body HTML:</label>';
                     html += '      <textarea id="matrix-body-' + config.Id + '" style="width: 100%; height: 200px;" onchange="updateMatrixConfigFromUI(\'' + config.Id + '\')">' + (config.Body || '') + '</textarea>';
+                    html += '      <div class="fieldDescription">Custom body wrapper template. Leave empty to use the default template.</div>';
                     html += '    </div>';
                     html += '    <div class="inputContainer">';
                     html += '      <label class="inputLabel inputLabelUnfocused">Entry HTML:</label>';
                     html += '      <textarea id="matrix-entry-' + config.Id + '" style="width: 100%; height: 200px;" onchange="updateMatrixConfigFromUI(\'' + config.Id + '\')">' + (config.Entry || '') + '</textarea>';
+                    html += '      <div class="fieldDescription">Custom entry template for each item. Leave empty to use the default template.</div>';
+                    html += '    </div>';
+                    html += '    <div class="inputContainer">';
+                    html += '      <label class="inputLabel inputLabelUnfocused">Header HTML:</label>';
+                    html += '      <textarea id="matrix-header-' + config.Id + '" style="width: 100%; height: 200px;" onchange="updateMatrixConfigFromUI(\'' + config.Id + '\')">' + (config.Header || '') + '</textarea>';
+                    html += '      <div class="fieldDescription">Custom section header template. Uses &lt;template&gt; tags with IDs: header-add, header-update, header-delete, header-upcoming. Leave empty to use the default template.</div>';
                     html += '    </div>';
                     html += '  </div>';
                     html += '</div>';

--- a/Jellyfin.Plugin.Newsletters/Templates/Classic/template_header.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Classic/template_header.html
@@ -1,0 +1,43 @@
+<template id="header-add">
+    <tr>
+        <td colspan='2' style='padding: 20px 10px 10px 10px;'>
+            <h2
+                style='color: #E197BC; margin: 0; font-size: 1.8em; border-bottom: 2px solid #E197BC; padding-bottom: 10px; display: flex;'>
+                <span style='margin-right: 4px;'>🎬</span> Added to {LibraryName}
+            </h2>
+        </td>
+    </tr>
+</template>
+
+<template id="header-update">
+    <tr>
+        <td colspan='2' style='padding: 20px 10px 10px 10px;'>
+            <h2
+                style='color: #007fb1; margin: 0; font-size: 1.8em; border-bottom: 2px solid #007fb1; padding-bottom: 10px; display: flex;'>
+                <span style='margin-right: 4px;'>🔄</span> Updated in {LibraryName}
+            </h2>
+        </td>
+    </tr>
+</template>
+
+<template id="header-delete">
+    <tr>
+        <td colspan='2' style='padding: 20px 10px 10px 10px;'>
+            <h2
+                style='color: #d190c5; margin: 0; font-size: 1.8em; border-bottom: 2px solid #d190c5; padding-bottom: 10px; display: flex;'>
+                <span style='margin-right: 4px;'>🗑️</span> Removed from {LibraryName}
+            </h2>
+        </td>
+    </tr>
+</template>
+
+<template id="header-upcoming">
+    <tr>
+        <td colspan='2' style='padding: 20px 10px 10px 10px;'>
+            <h2
+                style='color: #bf7df0; margin: 0; font-size: 1.8em; border-bottom: 2px solid #bf7df0; padding-bottom: 10px; display: flex;'>
+                <span style='margin-right: 4px;'>📅</span> Upcoming in {LibraryName}
+            </h2>
+        </td>
+    </tr>
+</template>

--- a/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_header.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_header.html
@@ -1,0 +1,15 @@
+<template id="header-add">
+<h2><font data-mx-color='#4CAF50'>🎬 Added to {LibraryName}</font></h2><hr/>
+</template>
+
+<template id="header-update">
+<h2><font data-mx-color='#2196F3'>🔄 Updated in {LibraryName}</font></h2><hr/>
+</template>
+
+<template id="header-delete">
+<h2><font data-mx-color='#F44336'>🗑️ Removed from {LibraryName}</font></h2><hr/>
+</template>
+
+<template id="header-upcoming">
+<h2><font data-mx-color='#FF8C00'>📅 Upcoming in {LibraryName}</font></h2><hr/>
+</template>

--- a/Jellyfin.Plugin.Newsletters/Templates/Modern/template_header.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Modern/template_header.html
@@ -1,0 +1,43 @@
+<template id="header-add">
+    <tr>
+        <td colspan='2' style='padding: 20px 10px 10px 10px;'>
+            <h2
+                style='color: #4CAF50; margin: 0; font-size: 1.8em; border-bottom: 2px solid #4CAF50; padding-bottom: 10px; display: flex;'>
+                <span style='margin-right: 4px;'>🎬</span> Added to {LibraryName}
+            </h2>
+        </td>
+    </tr>
+</template>
+
+<template id="header-update">
+    <tr>
+        <td colspan='2' style='padding: 20px 10px 10px 10px;'>
+            <h2
+                style='color: #2196F3; margin: 0; font-size: 1.8em; border-bottom: 2px solid #2196F3; padding-bottom: 10px; display: flex;'>
+                <span style='margin-right: 4px;'>🔄</span> Updated in {LibraryName}
+            </h2>
+        </td>
+    </tr>
+</template>
+
+<template id="header-delete">
+    <tr>
+        <td colspan='2' style='padding: 20px 10px 10px 10px;'>
+            <h2
+                style='color: #F44336; margin: 0; font-size: 1.8em; border-bottom: 2px solid #F44336; padding-bottom: 10px; display: flex;'>
+                <span style='margin-right: 4px;'>🗑️</span> Removed from {LibraryName}
+            </h2>
+        </td>
+    </tr>
+</template>
+
+<template id="header-upcoming">
+    <tr>
+        <td colspan='2' style='padding: 20px 10px 10px 10px;'>
+            <h2
+                style='color: #FF8C00; margin: 0; font-size: 1.8em; border-bottom: 2px solid #FF8C00; padding-bottom: 10px; display: flex;'>
+                <span style='margin-right: 4px;'>📅</span> Upcoming in {LibraryName}
+            </h2>
+        </td>
+    </tr>
+</template>

--- a/README.md
+++ b/README.md
@@ -282,6 +282,16 @@ You can select between different email templates:
 
 - Define custom HTML formatting for each individual media item (Movies/Series) in the newsletter. If left empty, the default HTML from the selected **Newsletter Template Category** will be used.
 
+### Header HTML
+
+- Define custom HTML for section headers (e.g., "Added to Movies", "Removed from Series"). The template uses `<template>` tags with IDs to define all four event-type headers in a single file:
+  - `<template id="header-add">` - Header for newly added items
+  - `<template id="header-update">` - Header for updated items
+  - `<template id="header-delete">` - Header for deleted items
+  - `<template id="header-upcoming">` - Header for upcoming items
+- **Placeholder**: `{LibraryName}` - replaced with the library name (e.g., "Movies", "TV Shows")
+- If left empty, the default header template from the selected **Newsletter Template Category** will be used.
+
 </details>
 
 <details>
@@ -392,6 +402,16 @@ You can select between different email templates:
 
 - Define custom HTML formatting for each individual media item (Movies/Series) in the newsletter. If left empty, the default HTML from the selected **Newsletter Template Category** will be used.
 
+### Header HTML
+
+- Define custom HTML for section headers (e.g., "Added to Movies", "Removed from Series"). The template uses `<template>` tags with IDs to define all four event-type headers in a single file:
+  - `<template id="header-add">` - Header for newly added items
+  - `<template id="header-update">` - Header for updated items
+  - `<template id="header-delete">` - Header for deleted items
+  - `<template id="header-upcoming">` - Header for upcoming items
+- **Placeholder**: `{LibraryName}` - replaced with the library name (e.g., "Movies", "TV Shows")
+- If left empty, the default header template from the selected **Newsletter Template Category** will be used.
+
 </details>
 
 # Issues
@@ -402,7 +422,7 @@ Please be patient with me, since I did this on the side of my normal job. But I 
 # Available HTML Data Tags
 
 Some of these may not interest that average user (if anyone), but I figured I would have any element in the Newsletters.db be available for use! `<br>`
-**NOTE:** *Examples of most tags can be found in the default Templates (template_modern_body.html AND template_modern_entry.html)*
+**NOTE:** *Examples of most tags can be found in the default Templates under `Templates/` (template_body.html, template_entry.html, template_header.html)*
 
 ## Required Tags
 
@@ -414,6 +434,7 @@ Some of these may not interest that average user (if anyone), but I figured I wo
 
 ```
 - {Date} - Auto-generated date of Newsletter email generation
+- {ServerURL} - The configured server URL for Jellyfin
 - {SeasonEpsInfo} - This tag is the Plugin-generated Season/Episode data
 - {Title} - Title of Movie/Series
 - {SeriesOverview} - Movie/Series overview
@@ -424,6 +445,7 @@ Some of these may not interest that average user (if anyone), but I figured I wo
 - {RunTime} - Movie/Episode Duration (for Series, gives first found duration. Will fix for only single episode or average in future update)
 - {OfficialRating} - TV-PG, TV-13, TV-14, etc.
 - {CommunityRating} - Numerical rating stored in Jellyfin's metadata
+- {LibraryName} - The library name (e.g., "Movies", "TV Shows") - used in the Header template
 ```
 
 ## Non-Recommended Tags
@@ -448,26 +470,26 @@ See 'issues' tab in GitHub with the label 'bug'
 The following features are planned for future releases:
 
 - [ ] **Support for delete events for series/season**
-  - Enhanced deletion tracking for series and individual seasons
-  - Improved cleanup of related data
+  - Deletion tracking for series and individual seasons
+  - Cleanup of related data
 
 - [ ] **Support for update events to update the database**
-  - Real-time database synchronization for item updates
+  - Database synchronization for item updates
   - Better handling of metadata changes and file upgrades
 
 - [ ] **Support for music/audio items**
   - Extend newsletter functionality to music libraries
   - Include album art, artist information, and track details
 
-- [x] **Multiple webhook/telegram ID/email/matrix room ID support with configurable parameters**
-  - Support for multiple notification endpoints per event type
-  - Individual configuration options for each recipient/channel
-  - Granular control over which events trigger newsletter for each endpoint
+- [x] ~~**Multiple webhook/telegram ID/email/matrix room ID support with configurable parameters**~~
+  - ~~Support for multiple notification endpoints per event type~~
+  - ~~Individual configuration options for each recipient/channel~~
+  - ~~Granular control over which events trigger newsletter for each endpoint~~
 
-- [x] **Upcoming series/episodes section for newsletter**
-  - Integration with Radarr and Sonarr for upcoming media tracking
-  - Configurable lead time for upcoming content newsletter
-  - Per-client toggle to enable/disable the upcoming section
+- [x] ~~**Upcoming series/episodes section for newsletter**~~
+  - ~~Integration with Radarr and Sonarr for upcoming media tracking~~
+  - ~~Configurable lead time for upcoming content newsletter~~
+  - ~~Per-client toggle to enable/disable the upcoming section~~
 
 # Contribute
 


### PR DESCRIPTION
This PR closes #55 and contains the following changes:

- Customizable section header templates for HTML clients. Section headers (e.g., "Added to Movies", "Removed from Series") are no longer hardcoded in code - they are now loaded from `template_header.html` files using `<template>` tags with IDs (`header-add`, `header-update`, `header-delete`, `header-upcoming`)
- Config page updated with Header HTML textarea and field descriptions for Body, Entry, and Header templates for both Email and Matrix clients.
- README updated with Header HTML documentation, updated available data tags, and corrected template file references.
