### PR TITLE
Updating SMTP secure options to auto

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Clients/Email/smtp.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Email/smtp.cs
@@ -154,7 +154,7 @@ public class SmtpMailer(IServerApplicationHost appHost,
             using (var client = new SmtpClient())
             {
                 client.CheckCertificateRevocation = false;
-                var secureOptions = enableSSL ? SecureSocketOptions.StartTls : SecureSocketOptions.None;
+                var secureOptions = enableSSL ? SecureSocketOptions.Auto : SecureSocketOptions.None;
                 client.Connect(smtpAddress, portNumber, secureOptions);
                 if (emailConfig.UseAuthentication)
                 {
@@ -362,7 +362,7 @@ public class SmtpMailer(IServerApplicationHost appHost,
                     {
                         client.Timeout = smtpTimeout;
                         client.CheckCertificateRevocation = false;
-                        var secureOptions = enableSSL ? SecureSocketOptions.StartTls : SecureSocketOptions.None;
+                        var secureOptions = enableSSL ? SecureSocketOptions.Auto : SecureSocketOptions.None;
                         client.Connect(smtpAddress, portNumber, secureOptions);
                         if (emailConfig.UseAuthentication)
                         {

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -1154,7 +1154,7 @@
                     html += '          <input id="email-ssl-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.EnableSsl !== false ? 'checked' : '') + ' onchange="updateEmailConfigFromUI(\'' + config.Id + '\')" />';
                     html += '          <span>Enable SSL/TLS</span>';
                     html += '        </label>';
-                    html += '        <div class="fieldDescription checkboxDescription">Secure the connection to the SMTP server. Most modern services require this.</div>';
+                    html += '        <div class="fieldDescription checkboxDescription">Secure the connection to the SMTP server using SSL/TLS or STARTTLS automatically based on the port.</div>';
                     html += '      </div>';
                     html += '      <div class="checkboxContainer checkboxContainer-withDescription" style="flex: 1; min-width: 200px;">';
                     html += '        <label class="emby-checkbox-label">';


### PR DESCRIPTION
This PR closes #61  and contains the following changes:

- Updated the SecureSocketOptions to Auto instead of StartTls for SMTP.