### PR TITLE
Showing testing error message in UI

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Clients/Discord/webhook.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Discord/webhook.cs
@@ -58,13 +58,14 @@ public class DiscordWebhook(IServerApplicationHost appHost,
     /// Sends a test message to a specific Discord webhook configuration to verify connectivity.
     /// </summary>
     /// <param name="configurationId">The ID of the Discord configuration to test.</param>
+    /// <returns>An <see cref="ActionResult"/> indicating success or failure.</returns>
     [HttpPost("SendDiscordTestMessage")]
-    public void SendDiscordTestMessage([FromQuery] string configurationId)
+    public ActionResult SendDiscordTestMessage([FromQuery] string configurationId)
     {
         if (string.IsNullOrEmpty(configurationId))
         {
             Logger.Error("Configuration ID is required for testing.");
-            return;
+            return BadRequest("Configuration ID is required for testing.");
         }
 
         var discordConfig = Config.DiscordConfigurations
@@ -73,13 +74,13 @@ public class DiscordWebhook(IServerApplicationHost appHost,
         if (discordConfig == null)
         {
             Logger.Error($"Discord configuration with ID '{configurationId}' not found.");
-            return;
+            return BadRequest($"Discord configuration with ID '{configurationId}' not found.");
         }
 
         if (!discordConfig.IsEnabled)
         {
             Logger.Info($"Discord configuration '{discordConfig.Name}' is disabled. Aborting test message.");
-            return;
+            return BadRequest($"Discord configuration '{discordConfig.Name}' is disabled. Aborting test message.");
         }
 
         // Split the Webhook URL by comma to support multiple webhooks
@@ -91,7 +92,7 @@ public class DiscordWebhook(IServerApplicationHost appHost,
         if (webhookUrls.Count == 0)
         {
             Logger.Info($"Discord configuration '{discordConfig.Name}' has no valid webhook URLs. Aborting test message.");
-            return;
+            return BadRequest($"Discord configuration '{discordConfig.Name}' has no valid webhook URLs. Aborting test message.");
         }
 
         bool anySuccess = false;
@@ -135,10 +136,12 @@ public class DiscordWebhook(IServerApplicationHost appHost,
         if (anySuccess)
         {
             Logger.Info($"Discord test message process completed for '{discordConfig.Name}'. At least one message verified.");
+            return Ok($"Discord test message sent successfully for '{discordConfig.Name}'.");
         }
         else
         {
             Logger.Error($"Discord test message process failed for all webhooks in '{discordConfig.Name}'.");
+            return BadRequest($"Discord test message process failed for all webhooks in '{discordConfig.Name}'.");
         }
     }
 

--- a/Jellyfin.Plugin.Newsletters/Clients/Email/smtp.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Email/smtp.cs
@@ -40,15 +40,16 @@ public class SmtpMailer(IServerApplicationHost appHost,
     /// Sends a test email using a specific email configuration.
     /// </summary>
     /// <param name="configurationId">The ID of the Email configuration to test.</param>
+    /// <returns>An <see cref="ActionResult"/> indicating success or failure.</returns>
     [HttpPost("SendTestMail")]
-    public void SendTestMail([FromQuery] string configurationId)
+    public ActionResult SendTestMail([FromQuery] string configurationId)
     {
         try
         {
             if (string.IsNullOrEmpty(configurationId))
             {
                 Logger.Error("Configuration ID is required for testing.");
-                return;
+                return BadRequest("Configuration ID is required for testing.");
             }
 
             var emailConfig = Config.EmailConfigurations
@@ -57,13 +58,13 @@ public class SmtpMailer(IServerApplicationHost appHost,
             if (emailConfig == null)
             {
                 Logger.Error($"Email configuration with ID '{configurationId}' not found.");
-                return;
+                return BadRequest($"Email configuration with ID '{configurationId}' not found.");
             }
 
             if (!emailConfig.IsEnabled)
             {
                 Logger.Info($"Email configuration '{emailConfig.Name}' is disabled. Aborting test message.");
-                return;
+                return BadRequest($"Email configuration '{emailConfig.Name}' is disabled. Aborting test message.");
             }
 
             Logger.Debug($"Sending out test mail for '{emailConfig.Name}'!");
@@ -110,7 +111,7 @@ public class SmtpMailer(IServerApplicationHost appHost,
             if (missingField)
             {
                 Logger.Error($"One or more required email configuration fields are missing for '{emailConfig.Name}'. Aborting send.");
-                return;
+                return BadRequest($"One or more required email configuration fields are missing for '{emailConfig.Name}'. Aborting send.");
             }
 
             HtmlBuilder hb = new(Logger, Db, emailConfig, LibraryManager, new List<JsonFileObj>());
@@ -166,10 +167,12 @@ public class SmtpMailer(IServerApplicationHost appHost,
             }
 
             Logger.Debug($"Test email sent successfully for '{emailConfig.Name}'.");
+            return Ok($"Test email sent successfully for '{emailConfig.Name}'.");
         }
         catch (Exception e)
         {
             Logger.Error("An error has occured: " + e);
+            return BadRequest("An error occurred while sending the test email.");
         }
     }
 

--- a/Jellyfin.Plugin.Newsletters/Clients/Telegram/TelegramClient.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Telegram/TelegramClient.cs
@@ -59,13 +59,14 @@ public class TelegramClient(IServerApplicationHost appHost,
     /// Sends a test message to a specific Telegram configuration to verify connectivity.
     /// </summary>
     /// <param name="configurationId">The ID of the Telegram configuration to test.</param>
+    /// <returns>An <see cref="ActionResult"/> indicating success or failure.</returns>
     [HttpPost("SendTelegramTestMessage")]
-    public void SendTelegramTestMessage([FromQuery] string configurationId)
+    public ActionResult SendTelegramTestMessage([FromQuery] string configurationId)
     {
         if (string.IsNullOrEmpty(configurationId))
         {
             Logger.Error("Configuration ID is required for testing.");
-            return;
+            return BadRequest("Configuration ID is required for testing.");
         }
 
         var telegramConfig = Config.TelegramConfigurations
@@ -74,19 +75,19 @@ public class TelegramClient(IServerApplicationHost appHost,
         if (telegramConfig == null)
         {
             Logger.Error($"Telegram configuration with ID '{configurationId}' not found.");
-            return;
+            return BadRequest($"Telegram configuration with ID '{configurationId}' not found.");
         }
 
         if (!telegramConfig.IsEnabled)
         {
             Logger.Info($"Telegram configuration '{telegramConfig.Name}' is disabled. Aborting test message.");
-            return;
+            return BadRequest($"Telegram configuration '{telegramConfig.Name}' is disabled. Aborting test message.");
         }
 
         if (string.IsNullOrEmpty(telegramConfig.BotToken) || string.IsNullOrEmpty(telegramConfig.ChatId))
         {
             Logger.Info($"Telegram configuration '{telegramConfig.Name}' has no bot token or chat ID. Aborting test message.");
-            return;
+            return BadRequest($"Telegram configuration '{telegramConfig.Name}' has no bot token or chat ID. Aborting test message.");
         }
 
         // Split ChatId by comma
@@ -98,7 +99,7 @@ public class TelegramClient(IServerApplicationHost appHost,
         if (chatIds.Count == 0)
         {
              Logger.Info($"Telegram configuration '{telegramConfig.Name}' has no valid chat IDs. Aborting test message.");
-             return;
+             return BadRequest($"Telegram configuration '{telegramConfig.Name}' has no valid chat IDs. Aborting test message.");
         }
 
         try
@@ -109,7 +110,7 @@ public class TelegramClient(IServerApplicationHost appHost,
             if (string.IsNullOrEmpty(testMessage))
             {
                 Logger.Error("Failed to build test message.");
-                return;
+                return BadRequest("Failed to build test message.");
             }
 
             bool anySuccess = false;
@@ -142,15 +143,18 @@ public class TelegramClient(IServerApplicationHost appHost,
             if (anySuccess)
             {
                 Logger.Info($"Telegram test message process completed for '{telegramConfig.Name}'. At least one message verified.");
+                return Ok($"Telegram test message sent successfully for '{telegramConfig.Name}'.");
             }
             else
             {
                 Logger.Error($"Telegram test message process failed for all Chat IDs in '{telegramConfig.Name}'.");
+                return BadRequest($"Telegram test message process failed for all Chat IDs in '{telegramConfig.Name}'.");
             }
         }
         catch (Exception e)
         {
             Logger.Error($"An error occurred while sending Telegram test message to '{telegramConfig.Name}': " + e);
+            return BadRequest($"An error occurred while sending Telegram test message to '{telegramConfig.Name}'.");
         }
     }
 

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -730,12 +730,20 @@
             function testDiscordConfig(id) {
                 Dashboard.showLoadingMsg();
                 var url = ApiClient.getUrl('Discord/SendDiscordTestMessage') + '?configurationId=' + encodeURIComponent(id);
-                ApiClient.ajax({ type: 'POST', url: url }).then(function () {
+                ApiClient.ajax({ type: 'POST', url: url, dataType: 'text' }).then(function (response) {
                     Dashboard.hideLoadingMsg();
-                    alert("Test Discord message sent! Check your webhook channel.");
+                    alert(response || "Test Discord message sent! Check your webhook channel.");
                 }).catch(function (err) {
                     Dashboard.hideLoadingMsg();
-                    alert("Failed to send test message. Check server logs for details.");
+                    var defaultMsg = "Failed to send test message. Check server logs for details.";
+                    if (err && typeof err.text === 'function') {
+                        err.text().then(function (text) { alert(text || defaultMsg); }).catch(function () { alert(defaultMsg); });
+                    } else {
+                        var msg = defaultMsg;
+                        if (err && err.responseText) msg = err.responseText;
+                        else if (typeof err === 'string') msg = err;
+                        alert(msg);
+                    }
                 });
             }
 
@@ -896,12 +904,20 @@
             function testTelegramConfig(id) {
                 Dashboard.showLoadingMsg();
                 var url = ApiClient.getUrl('Telegram/SendTelegramTestMessage') + '?configurationId=' + encodeURIComponent(id);
-                ApiClient.ajax({ type: 'POST', url: url }).then(function () {
+                ApiClient.ajax({ type: 'POST', url: url, dataType: 'text' }).then(function (response) {
                     Dashboard.hideLoadingMsg();
-                    alert("Test Telegram message sent! Check your chat.");
+                    alert(response || "Test Telegram message sent! Check your chat.");
                 }).catch(function (err) {
                     Dashboard.hideLoadingMsg();
-                    alert("Failed to send test message. Check server logs for details.");
+                    var defaultMsg = "Failed to send test message. Check server logs for details.";
+                    if (err && typeof err.text === 'function') {
+                        err.text().then(function (text) { alert(text || defaultMsg); }).catch(function () { alert(defaultMsg); });
+                    } else {
+                        var msg = defaultMsg;
+                        if (err && err.responseText) msg = err.responseText;
+                        else if (typeof err === 'string') msg = err;
+                        alert(msg);
+                    }
                 });
             }
 
@@ -1045,12 +1061,20 @@
             function testEmailConfig(id) {
                 Dashboard.showLoadingMsg();
                 var url = ApiClient.getUrl('SmtpMailer/SendTestMail') + '?configurationId=' + encodeURIComponent(id);
-                ApiClient.ajax({ type: 'POST', url: url }).then(function () {
+                ApiClient.ajax({ type: 'POST', url: url, dataType: 'text' }).then(function (response) {
                     Dashboard.hideLoadingMsg();
-                    alert("Test email sent! Check your inbox.");
+                    alert(response || "Test email sent! Check your inbox.");
                 }).catch(function (err) {
                     Dashboard.hideLoadingMsg();
-                    alert("Failed to send test email. Check server logs for details.");
+                    var defaultMsg = "Failed to send test email. Check server logs for details.";
+                    if (err && typeof err.text === 'function') {
+                        err.text().then(function (text) { alert(text || defaultMsg); }).catch(function () { alert(defaultMsg); });
+                    } else {
+                        var msg = defaultMsg;
+                        if (err && err.responseText) msg = err.responseText;
+                        else if (typeof err === 'string') msg = err;
+                        alert(msg);
+                    }
                 });
             }
 
@@ -1249,12 +1273,20 @@
             function testMatrixConfig(id) {
                 Dashboard.showLoadingMsg();
                 var url = ApiClient.getUrl('Matrix/SendMatrixTestMessage') + '?configurationId=' + encodeURIComponent(id);
-                ApiClient.ajax({ type: 'POST', url: url }).then(function () {
+                ApiClient.ajax({ type: 'POST', url: url, dataType: 'text' }).then(function (response) {
                     Dashboard.hideLoadingMsg();
-                    alert("Test Matrix message sent! Check your room.");
+                    alert(response || "Test Matrix message sent! Check your room.");
                 }).catch(function (err) {
                     Dashboard.hideLoadingMsg();
-                    alert("Failed to send test message. Check server logs for details.");
+                    var defaultMsg = "Failed to send test message. Check server logs for details.";
+                    if (err && typeof err.text === 'function') {
+                        err.text().then(function (text) { alert(text || defaultMsg); }).catch(function () { alert(defaultMsg); });
+                    } else {
+                        var msg = defaultMsg;
+                        if (err && err.responseText) msg = err.responseText;
+                        else if (typeof err === 'string') msg = err;
+                        alert(msg);
+                    }
                 });
             }
 


### PR DESCRIPTION
This PR contains the following changes:

- Every test function for clients now return ActionResult and is used to display the error message on UI, instead of a generic error message.