### PR TITLE
BUMP Mailkit version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.6.2.1
+
+- **Security Fix**: Updated MailKit from 4.14.1 to 4.16.0 to resolve moderate severity vulnerability
+
 # 1.6.2.0
 
 - **Feature**: Added customizable header templates for HTML clients

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.6.2.0</Version>
-        <AssemblyVersion>1.6.2.0</AssemblyVersion>
-        <FileVersion>1.6.2.0</FileVersion>
+        <Version>1.6.2.1</Version>
+        <AssemblyVersion>1.6.2.1</AssemblyVersion>
+        <FileVersion>1.6.2.1</FileVersion>
     </PropertyGroup>
 </Project>

--- a/Jellyfin.Plugin.Newsletters/Jellyfin.Plugin.Newsletters.csproj
+++ b/Jellyfin.Plugin.Newsletters/Jellyfin.Plugin.Newsletters.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="SQLitePCL.pretty.netstandard" Version="3.1.0" />
-    <PackageReference Include="MailKit" Version="4.14.1" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/Jellyfin.Plugin.Newsletters/manifest.json
+++ b/Jellyfin.Plugin.Newsletters/manifest.json
@@ -9,6 +9,14 @@
         "imageUrl": "https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/images/logo.png",
         "versions": [
             {
+                "version": "1.6.2.1",
+                "changelog": "- Security Fix: Updated MailKit from 4.14.1 to 4.16.0 to resolve moderate severity vulnerability.\n- FULL CHANGELOG: https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/CHANGELOG.md\n",
+                "targetAbi": "10.11.0.0",
+                "sourceUrl": "https://github.com/Sanidhya30/Jellyfin-Newsletter/releases/download/v1.6.2.1/newsletters_1.6.2.1.zip",
+                "checksum": "7aef5595b24566f9edd28d6e8e9dc7f3",
+                "timestamp": "2026-04-24T17:50:23Z"
+            },
+            {
                 "version": "1.6.2.0",
                 "changelog": "- Feature: Added customizable header templates for HTML clients.\n- Feature: Added enable/disable toggle for each client instance.\n- Bug Fix: Added unauthenticated SMTP support and auto-detected secure options for email clients.\n- Bug Fix: Improved mobile responsiveness for Classic template.\n- FULL CHANGELOG: https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/CHANGELOG.md\n",
                 "targetAbi": "10.11.0.0",

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 name: "Newsletters"
 guid: "60f478ab-2dd6-4ea0-af10-04d033f75979"
 imageUrl: "https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/images/logo.png"
-version: "1.6.2.0"
+version: "1.6.2.1"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Send newsletters for recently added/deleted/updated/upcoming media"
@@ -17,8 +17,5 @@ artifacts:
   - "MimeKit.dll"
   - "BouncyCastle.Cryptography.dll"
 changelog: |
-  - Feature: Added customizable header templates for HTML clients.
-  - Feature: Added enable/disable toggle for each client instance.
-  - Bug Fix: Added unauthenticated SMTP support and auto-detected secure options for email clients.
-  - Bug Fix: Improved mobile responsiveness for Classic template.
+  - Security Fix: Updated MailKit from 4.14.1 to 4.16.0 to resolve moderate severity vulnerability.
   - FULL CHANGELOG: https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/CHANGELOG.md

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,14 @@
         "imageUrl": "https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/images/logo.png",
         "versions": [
             {
+                "version": "1.6.2.1",
+                "changelog": "- Security Fix: Updated MailKit from 4.14.1 to 4.16.0 to resolve moderate severity vulnerability.\n- FULL CHANGELOG: https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/CHANGELOG.md\n",
+                "targetAbi": "10.11.0.0",
+                "sourceUrl": "https://github.com/Sanidhya30/Jellyfin-Newsletter/releases/download/v1.6.2.1/newsletters_1.6.2.1.zip",
+                "checksum": "7aef5595b24566f9edd28d6e8e9dc7f3",
+                "timestamp": "2026-04-24T17:50:23Z"
+            },
+            {
                 "version": "1.6.2.0",
                 "changelog": "- Feature: Added customizable header templates for HTML clients.\n- Feature: Added enable/disable toggle for each client instance.\n- Bug Fix: Added unauthenticated SMTP support and auto-detected secure options for email clients.\n- Bug Fix: Improved mobile responsiveness for Classic template.\n- FULL CHANGELOG: https://raw.githubusercontent.com/Sanidhya30/Jellyfin-Newsletter/master/CHANGELOG.md\n",
                 "targetAbi": "10.11.0.0",


### PR DESCRIPTION
This PR closes #67 and contains the following changes:

- Updated MailKit from 4.14.1 to 4.16.0 to resolve moderate severity vulnerability.
- Build for v1.6.2.1