### PR TITLE
New date tags for HTML clients

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Clients/Client.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Client.cs
@@ -60,6 +60,10 @@ public class Client(Logger loggerInstance,
             // copy tables - use INSERT OR REPLACE to handle potential conflicts
             Db.ExecuteSQL("INSERT OR REPLACE INTO ArchiveData SELECT * FROM CurrNewsletterData;");
             Db.ExecuteSQL("DELETE FROM CurrNewsletterData;");
+
+            // Update and save the last published date
+            Config.LastPublishedDate = DateTime.Now;
+            Plugin.Instance!.SaveConfiguration();
         }
         catch (Exception e)
         {

--- a/Jellyfin.Plugin.Newsletters/Clients/Email/smtp.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Email/smtp.cs
@@ -119,8 +119,7 @@ public class SmtpMailer(IServerApplicationHost appHost,
             string body = hb.GetDefaultHTMLBody(emailConfig);
             string builtString = hb.BuildHtmlStringsForTest(emailConfig);
             builtString = hb.TemplateReplace(HtmlBuilder.ReplaceBodyWithBuiltString(body, builtString), "{ServerURL}", Config.Hostname);
-            string currDate = DateTime.Today.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
-            builtString = builtString.Replace("{Date}", currDate, StringComparison.Ordinal);
+            builtString = hb.ReplaceDatePlaceholders(builtString);
 
             var mail = new MimeMessage();
             mail.From.Add(new MailboxAddress(emailFromAddress, emailFromAddress));
@@ -290,8 +289,6 @@ public class SmtpMailer(IServerApplicationHost appHost,
             string body = hb.GetDefaultHTMLBody(emailConfig);
             ReadOnlyCollection<(string HtmlString, List<(MemoryStream? ImageStream, string ContentId)> InlineImages)> chunks = hb.BuildChunkedHtmlStringsFromNewsletterData(applicationHost.SystemId, emailConfig);
 
-            string currDate = DateTime.Today.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
-
             int partNum = 1; // for multi-part email subjects if needed
             foreach (var (builtString, inlineImages) in chunks)
             {
@@ -299,8 +296,8 @@ public class SmtpMailer(IServerApplicationHost appHost,
                 {
                     Logger.Debug($"Email part {partNum} for '{emailConfig.Name}' image count: {inlineImages.Count}");
                     // Add template substitutions
-                    string finalBody = hb.TemplateReplace(HtmlBuilder.ReplaceBodyWithBuiltString(body, builtString), "{ServerURL}", Config.Hostname)
-                                        .Replace("{Date}", currDate, StringComparison.Ordinal);
+                    string finalBody = hb.ReplaceDatePlaceholders(
+                        hb.TemplateReplace(HtmlBuilder.ReplaceBodyWithBuiltString(body, builtString), "{ServerURL}", Config.Hostname));
 
                     var mail = new MimeMessage();
                     mail.From.Add(new MailboxAddress(emailFromAddress, emailFromAddress));

--- a/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
@@ -154,6 +154,55 @@ public abstract class HtmlContentBuilder(
     }
 
     /// <summary>
+    /// Replaces all date-related placeholders in the given string using the server's configured culture.
+    /// Supported: {Date}, {dd}, {d}, {day}, {dy}, {mm}, {month}, {mon}, {yy}, {yyyy}.
+    /// </summary>
+    /// <param name="html">The string containing date placeholders to replace.</param>
+    /// <returns>The string with all date placeholders resolved.</returns>
+    public string ReplaceDatePlaceholders(string html)
+    {
+        var culture = GetConfiguredCulture();
+        var today = DateTime.Today;
+
+        html = this.TemplateReplace(html, "{Date}", today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+        html = this.TemplateReplace(html, "{dd}", today.ToString("dd", culture));
+        html = this.TemplateReplace(html, "{d}", today.Day.ToString(culture));
+        html = this.TemplateReplace(html, "{day}", today.ToString("dddd", culture));
+        html = this.TemplateReplace(html, "{dy}", today.ToString("ddd", culture));
+        html = this.TemplateReplace(html, "{mm}", today.ToString("MM", culture));
+        html = this.TemplateReplace(html, "{month}", today.ToString("MMMM", culture));
+        html = this.TemplateReplace(html, "{mon}", today.ToString("MMM", culture));
+        html = this.TemplateReplace(html, "{yy}", today.ToString("yy", culture));
+        html = this.TemplateReplace(html, "{yyyy}", today.ToString("yyyy", culture));
+
+        return html;
+    }
+
+    /// <summary>
+    /// Resolves the culture to use for date formatting.
+    /// Reads from the Jellyfin server's UICulture setting, falling back to InvariantCulture.
+    /// </summary>
+    /// <returns>The resolved CultureInfo.</returns>
+    private CultureInfo GetConfiguredCulture()
+    {
+        try
+        {
+            var uiCulture = Plugin.ServerConfigurationManager?.Configuration?.UICulture;
+            if (!string.IsNullOrWhiteSpace(uiCulture))
+            {
+                Logger.Debug($"Using Jellyfin server UICulture for date formatting: {uiCulture}");
+                return new CultureInfo(uiCulture);
+            }
+        }
+        catch (CultureNotFoundException ex)
+        {
+            Logger.Warn($"Jellyfin server UICulture could not be resolved: {ex.Message}. Falling back to InvariantCulture.");
+        }
+
+        return CultureInfo.InvariantCulture;
+    }
+
+    /// <summary>
     /// Replaces the {EntryData} placeholder in the newsletter body with the provided newsletter data string.
     /// </summary>
     /// <param name="body">The HTML body template containing the {EntryData} placeholder.</param>

--- a/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
@@ -155,25 +155,33 @@ public abstract class HtmlContentBuilder(
 
     /// <summary>
     /// Replaces all date-related placeholders in the given string using the server's configured culture.
-    /// Supported: {Date}, {dd}, {d}, {day}, {dy}, {mm}, {month}, {mon}, {yy}, {yyyy}.
     /// </summary>
     /// <param name="html">The string containing date placeholders to replace.</param>
     /// <returns>The string with all date placeholders resolved.</returns>
     public string ReplaceDatePlaceholders(string html)
     {
-        var culture = GetConfiguredCulture();
-        var today = DateTime.Today;
+        html = ReplaceDatePlaceholdersInternal(html, DateTime.Today, string.Empty);
+        html = ReplaceDatePlaceholdersInternal(html, Config.LastPublishedDate, "prev");
+        return html;
+    }
 
-        html = this.TemplateReplace(html, "{Date}", today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
-        html = this.TemplateReplace(html, "{dd}", today.ToString("dd", culture));
-        html = this.TemplateReplace(html, "{d}", today.Day.ToString(culture));
-        html = this.TemplateReplace(html, "{day}", today.ToString("dddd", culture));
-        html = this.TemplateReplace(html, "{dy}", today.ToString("ddd", culture));
-        html = this.TemplateReplace(html, "{mm}", today.ToString("MM", culture));
-        html = this.TemplateReplace(html, "{month}", today.ToString("MMMM", culture));
-        html = this.TemplateReplace(html, "{mon}", today.ToString("MMM", culture));
-        html = this.TemplateReplace(html, "{yy}", today.ToString("yy", culture));
-        html = this.TemplateReplace(html, "{yyyy}", today.ToString("yyyy", culture));
+    private string ReplaceDatePlaceholdersInternal(string html, DateTime? date, string prefix)
+    {
+        // Default to Unix Epoch (Jan 1, 1970) if no previous date is found
+        var d = date ?? DateTime.UnixEpoch;
+        var culture = GetConfiguredCulture();
+
+        html = this.TemplateReplace(html, $"{{{prefix}Date}}",  d.ToString("d", culture));
+        html = this.TemplateReplace(html, $"{{{prefix}d}}",     d.Day.ToString(culture));
+        html = this.TemplateReplace(html, $"{{{prefix}dd}}",    d.ToString("dd", culture));
+        html = this.TemplateReplace(html, $"{{{prefix}day}}",   d.ToString("dddd", culture));
+        html = this.TemplateReplace(html, $"{{{prefix}dy}}",    d.ToString("ddd", culture));
+        html = this.TemplateReplace(html, $"{{{prefix}m}}",     d.Month.ToString(culture));
+        html = this.TemplateReplace(html, $"{{{prefix}mm}}",    d.ToString("MM", culture));
+        html = this.TemplateReplace(html, $"{{{prefix}month}}", d.ToString("MMMM", culture));
+        html = this.TemplateReplace(html, $"{{{prefix}mon}}",   d.ToString("MMM", culture));
+        html = this.TemplateReplace(html, $"{{{prefix}yy}}",    d.ToString("yy", culture));
+        html = this.TemplateReplace(html, $"{{{prefix}yyyy}}",  d.ToString("yyyy", culture));
 
         return html;
     }

--- a/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixClient.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixClient.cs
@@ -103,10 +103,8 @@ public class MatrixClient(IServerApplicationHost appHost,
         {
             var builder = new MatrixMessageBuilder(Logger, Db, LibraryManager, new List<JsonFileObj>());
             var htmlBody = builder.BuildMessageForTest(matrixConfig);
-            string currDate = DateTime.Today.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
-                    
             htmlBody = builder.TemplateReplace(htmlBody, "{ServerURL}", Config.Hostname);
-            htmlBody = htmlBody.Replace("{Date}", currDate, StringComparison.Ordinal);
+            htmlBody = builder.ReplaceDatePlaceholders(htmlBody);
 
             bool anySuccess = false;
             foreach (var roomId in roomIds)
@@ -185,10 +183,8 @@ public class MatrixClient(IServerApplicationHost appHost,
 
                     var builder = new MatrixMessageBuilder(Logger, Db, LibraryManager, matrixConfig.NewsletterOnUpcomingItemEnabled ? upcomingItems : Array.Empty<JsonFileObj>());
                     var htmlBody = builder.BuildMessageFromNewsletterData(applicationHost.SystemId, matrixConfig);
-                    string currDate = DateTime.Today.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
-                    
                     htmlBody = builder.TemplateReplace(htmlBody, "{ServerURL}", Config.Hostname);
-                    htmlBody = htmlBody.Replace("{Date}", currDate, StringComparison.Ordinal);
+                    htmlBody = builder.ReplaceDatePlaceholders(htmlBody);
 
                     foreach (var roomId in roomIds)
                     {

--- a/Jellyfin.Plugin.Newsletters/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/PluginConfiguration.cs
@@ -150,6 +150,12 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     public bool DebugMode { get; set; }
 
+    /// <summary>
+    /// Gets or sets the date the last newsletter was successfully published.
+    /// Null if no newsletter has been sent yet.
+    /// </summary>
+    public DateTime? LastPublishedDate { get; set; } = null;
+
     // Server Details
 
     /// <summary>

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -44,6 +44,11 @@
                             </div>
                         </div>
 
+                        <div class="fieldDescription" style="margin-bottom: 15px;">
+                            <b>Last Newsletter Sent:</b> <span id="LastPublishedDateDisplay"
+                                style="color: #00a4dc;">Never</span>
+                        </div>
+
                         <div class="inputContainer" id="CommunityRatingDecimals">
                             <label class="inputLabel inputLabelUnfocused" for="CommunityRatingDecimalPlaces">Community
                                 Rating Decimal Places:</label>
@@ -1455,6 +1460,17 @@
             function loadConfig() {
                 ApiClient.getPluginConfiguration(NewsletterConfig.pluginUniqueId).then(function (config) {
                     console.log("Loading config...", config);
+
+                    // Display Last Published Date
+                    var dateDisplayEl = document.getElementById('LastPublishedDateDisplay');
+                    if (dateDisplayEl) {
+                        if (config.LastPublishedDate) {
+                            var date = new Date(config.LastPublishedDate);
+                            dateDisplayEl.textContent = date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
+                        } else {
+                            dateDisplayEl.textContent = 'Never';
+                        }
+                    }
 
                     // General tab fields
                     FIELDS.checkboxes.forEach(function (id) {

--- a/Jellyfin.Plugin.Newsletters/Plugin.cs
+++ b/Jellyfin.Plugin.Newsletters/Plugin.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using Jellyfin.Plugin.Newsletters.Configuration;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
+using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
 
@@ -19,10 +20,12 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// </summary>
     /// <param name="applicationPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
     /// <param name="xmlSerializer">Instance of the <see cref="IXmlSerializer"/> interface.</param>
-    public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer)
+    /// <param name="serverConfigManager">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
+    public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, IServerConfigurationManager serverConfigManager)
         : base(applicationPaths, xmlSerializer)
     {
         Instance = this;
+        ServerConfigurationManager = serverConfigManager;
 
         static void SetConfigPaths(IApplicationPaths dataPaths)
         {
@@ -57,6 +60,11 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// Gets the current plugin instance.
     /// </summary>
     public static Plugin? Instance { get; private set; }
+
+    /// <summary>
+    /// Gets the server configuration manager instance for accessing server-wide settings.
+    /// </summary>
+    public static IServerConfigurationManager? ServerConfigurationManager { get; private set; }
 
     /// <inheritdoc />
     public IEnumerable<PluginPageInfo> GetPages()

--- a/Jellyfin.Plugin.Newsletters/Templates/Classic/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Classic/template_body.html
@@ -14,7 +14,7 @@
 										Jellyfin Newsletter
 									</a>
 								</h1>
-								<h3 id="Date" style="color:#FFFFFF;margin:0px;">{Date}</h3>
+								<h3 id="Date" style="color:#FFFFFF;margin:0px;">{d} {month}, {yyyy}</h3>
 							</td>
 						</tr>
 						<tr>

--- a/Jellyfin.Plugin.Newsletters/Templates/Classic/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Classic/template_body.html
@@ -14,7 +14,8 @@
 										Jellyfin Newsletter
 									</a>
 								</h1>
-								<h3 id="Date" style="color:#FFFFFF;margin:0px;">{d} {mon} {yyyy}</h3>
+								<h3 id="Date" style="color:#FFFFFF;margin:0px;">{prevd} {prevmon} {prevyyyy} - {d} {mon}
+									{yyyy}</h3>
 							</td>
 						</tr>
 						<tr>

--- a/Jellyfin.Plugin.Newsletters/Templates/Classic/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Classic/template_body.html
@@ -14,7 +14,7 @@
 										Jellyfin Newsletter
 									</a>
 								</h1>
-								<h3 id="Date" style="color:#FFFFFF;margin:0px;">{d} {month}, {yyyy}</h3>
+								<h3 id="Date" style="color:#FFFFFF;margin:0px;">{d} {mon} {yyyy}</h3>
 							</td>
 						</tr>
 						<tr>

--- a/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_body.html
@@ -2,6 +2,6 @@
     <a href="{ServerURL}" target="_blank">Jellyfin Newsletter</a>
 </h1>
 <small>
-    <font data-mx-color="#a0a0a0">{d} {month}, {yyyy}</font>
+    <font data-mx-color="#a0a0a0">{d} {mon} {yyyy}</font>
 </small>
 {EntryData}

--- a/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_body.html
@@ -2,6 +2,6 @@
     <a href="{ServerURL}" target="_blank">Jellyfin Newsletter</a>
 </h1>
 <small>
-    <font data-mx-color="#a0a0a0">{d} {mon} {yyyy}</font>
+    <font data-mx-color="#a0a0a0">{prevd} {prevmon} {prevyyyy} - {d} {mon} {yyyy}</font>
 </small>
 {EntryData}

--- a/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_body.html
@@ -2,6 +2,6 @@
     <a href="{ServerURL}" target="_blank">Jellyfin Newsletter</a>
 </h1>
 <small>
-    <font data-mx-color="#a0a0a0">{Date}</font>
+    <font data-mx-color="#a0a0a0">{d} {month}, {yyyy}</font>
 </small>
 {EntryData}

--- a/Jellyfin.Plugin.Newsletters/Templates/Modern/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Modern/template_body.html
@@ -73,7 +73,6 @@
 			margin-top: 5px;
 			font-size: 14px;
 			color: #a0a0a0;
-			text-transform: uppercase;
 			letter-spacing: 1px;
 		}
 
@@ -181,7 +180,7 @@
 							Jellyfin Newsletter
 						</a>
 					</h1>
-					<div class="header-date">{Date}</div>
+					<div class="header-date">{d} {month}, {yyyy}</div>
 				</td>
 			</tr>
 

--- a/Jellyfin.Plugin.Newsletters/Templates/Modern/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Modern/template_body.html
@@ -180,7 +180,7 @@
 							Jellyfin Newsletter
 						</a>
 					</h1>
-					<div class="header-date">{d} {mon} {yyyy}</div>
+					<div class="header-date">{prevd} {prevmon} {prevyyyy} - {d} {mon} {yyyy}</div>
 				</td>
 			</tr>
 

--- a/Jellyfin.Plugin.Newsletters/Templates/Modern/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Modern/template_body.html
@@ -180,7 +180,7 @@
 							Jellyfin Newsletter
 						</a>
 					</h1>
-					<div class="header-date">{d} {month}, {yyyy}</div>
+					<div class="header-date">{d} {mon} {yyyy}</div>
 				</td>
 			</tr>
 

--- a/README.md
+++ b/README.md
@@ -433,7 +433,16 @@ Some of these may not interest that average user (if anyone), but I figured I wo
 ## Recommended Tags
 
 ```
-- {Date} - Auto-generated date of Newsletter email generation
+- {Date} - Auto-generated date (yyyy-MM-dd format)
+- {d} - Day of the month (e.g. 9, 23)
+- {dd} - Zero-padded day of the month (e.g. 09, 23)
+- {day} - Full day name (e.g. Wednesday)
+- {dy} - Short day name (e.g. Wed)
+- {mm} - Zero-padded month (e.g. 04)
+- {month} - Full month name (e.g. April)
+- {mon} - Short month name (e.g. Apr)
+- {yy} - Two-digit year (e.g. 26)
+- {yyyy} - Four-digit year (e.g. 2026)
 - {ServerURL} - The configured server URL for Jellyfin
 - {SeasonEpsInfo} - This tag is the Plugin-generated Season/Episode data
 - {Title} - Title of Movie/Series

--- a/README.md
+++ b/README.md
@@ -432,17 +432,37 @@ Some of these may not interest that average user (if anyone), but I figured I wo
 
 ## Recommended Tags
 
+<details>
+<summary><b>Date Formatting Tags (Click to expand)</b></summary>
+
 ```
 - {Date} - Auto-generated date (yyyy-MM-dd format)
 - {d} - Day of the month (e.g. 9, 23)
 - {dd} - Zero-padded day of the month (e.g. 09, 23)
 - {day} - Full day name (e.g. Wednesday)
 - {dy} - Short day name (e.g. Wed)
-- {mm} - Zero-padded month (e.g. 04)
+- {m} - Month of the year (e.g. 4, 11)
+- {mm} - Zero-padded month (e.g. 04, 11)
 - {month} - Full month name (e.g. April)
 - {mon} - Short month name (e.g. Apr)
 - {yy} - Two-digit year (e.g. 26)
 - {yyyy} - Four-digit year (e.g. 2026)
+
+- {prevDate} - Date of previous newsletter (legacy yyyy-MM-dd format)
+- {prevd} - Day of the month of previous newsletter (e.g. 9, 23)
+- {prevdd} - Zero-padded day of the month of previous newsletter (e.g. 09, 23)
+- {prevday} - Full day name of previous newsletter (e.g. Wednesday)
+- {prevdy} - Short day name of previous newsletter (e.g. Wed)
+- {prevm} - Month of the year of previous newsletter (e.g. 4, 11)
+- {prevmm} - Zero-padded month of previous newsletter (e.g. 04, 11)
+- {prevmonth} - Full month name of previous newsletter (e.g. April)
+- {prevmon} - Short month name of previous newsletter (e.g. Apr)
+- {prevyy} - Two-digit year of previous newsletter (e.g. 26)
+- {prevyyyy} - Four-digit year of previous newsletter (e.g. 2026)
+```
+</details>
+
+```
 - {ServerURL} - The configured server URL for Jellyfin
 - {SeasonEpsInfo} - This tag is the Plugin-generated Season/Episode data
 - {Title} - Title of Movie/Series


### PR DESCRIPTION
This PR closes #53, #56 and contains the following changes:

- Support for `LastPublishedDate` configuration to persist the timestamp of the last generated newsletter.
- New tags such as `{d}, {dd}, {day}, {dy}, {m}, {mm}, {month}, {mon}, {yy}, {yyyy}, {prevDate}, {prevd}, {prevdd}, {prevday}, {prevdy}, {prevm}, {prevmm}, {prevmonth}, {prevmon}, {prevyy}, and {prevyyyy}` can be used for formatting the date.
- Updated default Classic, Modern, and Matrix templates to display newsletter new format date.
- `configPage.html` updated to show the "Last Newsletter Sent" date.