### PR TITLE
Genres tag for newsletter

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Clients/Discord/EmbedBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Discord/EmbedBuilder.cs
@@ -73,6 +73,7 @@ public class EmbedBuilder(
                 AddFieldIfEnabled(fieldsList, discordConfig.RatingEnabled, "Rating", item.CommunityRating > 0 ? item.CommunityRating.Value.ToString($"F{Config.CommunityRatingDecimalPlaces}", CultureInfo.InvariantCulture) : "N/A");
                 AddFieldIfEnabled(fieldsList, discordConfig.PGRatingEnabled, "PG rating", item.OfficialRating ?? "N/A");
                 AddFieldIfEnabled(fieldsList, discordConfig.DurationEnabled, "Duration", item.RunTime > 0 ? $"{item.RunTime} min" : "N/A");
+                AddFieldIfEnabled(fieldsList, discordConfig.GenresEnabled, "Genres", item.Genres);
                 AddFieldIfEnabled(fieldsList, discordConfig.EpisodesEnabled, "Episodes", seaEps, false);
 
                 // Add event type query otherwise discord deduplicate the embed with same url
@@ -172,6 +173,7 @@ public class EmbedBuilder(
             AddFieldIfEnabled(fieldsList, discordConfig.RatingEnabled, "Rating", item.CommunityRating?.ToString($"F{Config.CommunityRatingDecimalPlaces}", CultureInfo.InvariantCulture) ?? "N/A");
             AddFieldIfEnabled(fieldsList, discordConfig.PGRatingEnabled, "PG rating", item.OfficialRating ?? "N/A");
             AddFieldIfEnabled(fieldsList, discordConfig.DurationEnabled, "Duration", $"{item.RunTime} min");
+            AddFieldIfEnabled(fieldsList, discordConfig.GenresEnabled, "Genres", item.Genres);
             AddFieldIfEnabled(fieldsList, discordConfig.EpisodesEnabled, "Episodes", seaEps, false);
 
             string embedUrl = string.IsNullOrEmpty(Config.Hostname) 

--- a/Jellyfin.Plugin.Newsletters/Clients/Telegram/TelegramMessageBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Telegram/TelegramMessageBuilder.cs
@@ -211,6 +211,11 @@ public class TelegramMessageBuilder(
             messageBuilder.AppendLine(CultureInfo.InvariantCulture, $"Duration: {(item.RunTime > 0 ? $"{item.RunTime} min" : "N/A")}");
         }
 
+        if (telegramConfig.GenresEnabled && !string.IsNullOrWhiteSpace(item.Genres))
+        {
+            messageBuilder.AppendLine(CultureInfo.InvariantCulture, $"Genres: {EscapeMarkdown(item.Genres)}");
+        }
+
         return messageBuilder.ToString().Trim();
     }
 

--- a/Jellyfin.Plugin.Newsletters/Configuration/DiscordConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/DiscordConfiguration.cs
@@ -64,6 +64,11 @@ public class DiscordConfiguration : INewsletterConfiguration
     public bool EpisodesEnabled { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether genres should be visible in Discord embed.
+    /// </summary>
+    public bool GenresEnabled { get; set; } = false;
+
+    /// <summary>
     /// Gets or sets the embed color for series add events.
     /// </summary>
     public string SeriesAddEmbedColor { get; set; } = "#00ff00";

--- a/Jellyfin.Plugin.Newsletters/Configuration/TelegramConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/TelegramConfiguration.cs
@@ -64,6 +64,11 @@ public class TelegramConfiguration : INewsletterConfiguration
     public bool EpisodesEnabled { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether genres should be visible in Telegram messages.
+    /// </summary>
+    public bool GenresEnabled { get; set; } = false;
+
+    /// <summary>
     /// Gets or sets the collection of selected series libraries.
     /// </summary>
     public Collection<string> SelectedSeriesLibraries { get; set; } = new Collection<string>();

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -717,6 +717,7 @@
                     PGRatingEnabled: true,
                     DurationEnabled: true,
                     EpisodesEnabled: true,
+                    GenresEnabled: false,
                     SeriesAddEmbedColor: '#00FF00',
                     SeriesDeleteEmbedColor: '#FF0000',
                     SeriesUpdateEmbedColor: '#0000FF',
@@ -782,6 +783,7 @@
                 config.PGRatingEnabled = document.getElementById('discord-pgrating-' + id).checked;
                 config.DurationEnabled = document.getElementById('discord-duration-' + id).checked;
                 config.EpisodesEnabled = document.getElementById('discord-episodes-' + id).checked;
+                config.GenresEnabled = document.getElementById('discord-genres-' + id).checked;
                 config.SeriesAddEmbedColor = document.getElementById('discord-series-add-color-' + id).value;
                 config.SeriesDeleteEmbedColor = document.getElementById('discord-series-delete-color-' + id).value;
                 config.SeriesUpdateEmbedColor = document.getElementById('discord-series-update-color-' + id).value;
@@ -853,9 +855,10 @@
                     html += '        <td><div class="checkboxContainer"><label class="emby-checkbox-label"><input id="discord-desc-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.DescriptionEnabled ? 'checked' : '') + ' onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"><span>Description</span></label></div></td>';
                     html += '        <td><div class="checkboxContainer"><label class="emby-checkbox-label"><input id="discord-thumb-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.ThumbnailEnabled ? 'checked' : '') + ' onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"><span>Thumbnail</span></label></div></td>';
                     html += '        <td><div class="checkboxContainer"><label class="emby-checkbox-label"><input id="discord-rating-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.RatingEnabled ? 'checked' : '') + ' onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"><span>Rating</span></label></div></td>';
-                    html += '      </tr><tr>';
                     html += '        <td><div class="checkboxContainer"><label class="emby-checkbox-label"><input id="discord-pgrating-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.PGRatingEnabled ? 'checked' : '') + ' onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"><span>PG Rating</span></label></div></td>';
+                    html += '      </tr><tr>';
                     html += '        <td><div class="checkboxContainer"><label class="emby-checkbox-label"><input id="discord-duration-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.DurationEnabled ? 'checked' : '') + ' onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"><span>Duration</span></label></div></td>';
+                    html += '        <td><div class="checkboxContainer"><label class="emby-checkbox-label"><input id="discord-genres-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.GenresEnabled ? 'checked' : '') + ' onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"><span>Genres</span></label></div></td>';
                     html += '        <td><div class="checkboxContainer"><label class="emby-checkbox-label"><input id="discord-episodes-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.EpisodesEnabled ? 'checked' : '') + ' onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"><span>Episodes</span></label></div></td>';
                     html += '      </tr></table>';
                     html += '    </div>';
@@ -897,6 +900,7 @@
                     PGRatingEnabled: true,
                     DurationEnabled: true,
                     EpisodesEnabled: true,
+                    GenresEnabled: false,
                     SelectedSeriesLibraries: [],
                     SelectedMoviesLibraries: [],
                     NewsletterOnItemAddedEnabled: true,
@@ -956,6 +960,7 @@
                 config.PGRatingEnabled = document.getElementById('telegram-pgrating-' + id).checked;
                 config.DurationEnabled = document.getElementById('telegram-duration-' + id).checked;
                 config.EpisodesEnabled = document.getElementById('telegram-episodes-' + id).checked;
+                config.GenresEnabled = document.getElementById('telegram-genres-' + id).checked;
 
                 // Update Event Toggles
                 config.NewsletterOnItemAddedEnabled = document.getElementById('telegram-event-add-' + id).checked;
@@ -1021,9 +1026,10 @@
                     html += '        <td><div class="checkboxContainer"><label class="emby-checkbox-label"><input id="telegram-desc-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.DescriptionEnabled ? 'checked' : '') + ' onchange="updateTelegramConfigFromUI(\'' + config.Id + '\')"><span>Description</span></label></div></td>';
                     html += '        <td><div class="checkboxContainer"><label class="emby-checkbox-label"><input id="telegram-thumb-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.ThumbnailEnabled ? 'checked' : '') + ' onchange="updateTelegramConfigFromUI(\'' + config.Id + '\')"><span>Thumbnail</span></label></div></td>';
                     html += '        <td><div class="checkboxContainer"><label class="emby-checkbox-label"><input id="telegram-rating-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.RatingEnabled ? 'checked' : '') + ' onchange="updateTelegramConfigFromUI(\'' + config.Id + '\')"><span>Rating</span></label></div></td>';
-                    html += '      </tr><tr>';
                     html += '        <td><div class="checkboxContainer"><label class="emby-checkbox-label"><input id="telegram-pgrating-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.PGRatingEnabled ? 'checked' : '') + ' onchange="updateTelegramConfigFromUI(\'' + config.Id + '\')"><span>PG Rating</span></label></div></td>';
+                    html += '      </tr><tr>';
                     html += '        <td><div class="checkboxContainer"><label class="emby-checkbox-label"><input id="telegram-duration-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.DurationEnabled ? 'checked' : '') + ' onchange="updateTelegramConfigFromUI(\'' + config.Id + '\')"><span>Duration</span></label></div></td>';
+                    html += '        <td><div class="checkboxContainer"><label class="emby-checkbox-label"><input id="telegram-genres-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.GenresEnabled ? 'checked' : '') + ' onchange="updateTelegramConfigFromUI(\'' + config.Id + '\')"><span>Genres</span></label></div></td>';
                     html += '        <td><div class="checkboxContainer"><label class="emby-checkbox-label"><input id="telegram-episodes-' + config.Id + '" type="checkbox" is="emby-checkbox" ' + (config.EpisodesEnabled ? 'checked' : '') + ' onchange="updateTelegramConfigFromUI(\'' + config.Id + '\')"><span>Episodes</span></label></div></td>';
                     html += '      </tr></table>';
                     html += '    </div>';

--- a/Jellyfin.Plugin.Newsletters/Scanner/Scraper.cs
+++ b/Jellyfin.Plugin.Newsletters/Scanner/Scraper.cs
@@ -300,7 +300,7 @@ public class Scraper
     private void AddItemToDatabase(JsonFileObj item, string eventType)
     {
         item = NoNull(item);
-        db.ExecuteSQL("INSERT INTO CurrRunData (Filename, Title, Season, Episode, SeriesOverview, ImageURL, ItemID, PosterPath, Type, PremiereYear, RunTime, OfficialRating, CommunityRating, EventType, LibraryId) " +
+        db.ExecuteSQL("INSERT INTO CurrRunData (Filename, Title, Season, Episode, SeriesOverview, ImageURL, ItemID, PosterPath, Type, PremiereYear, RunTime, OfficialRating, CommunityRating, EventType, LibraryId, Genres) " +
                 "VALUES (" +
                     SanitizeDbItem(item.Filename) +
                     "," + SanitizeDbItem(item.Title) +
@@ -317,6 +317,7 @@ public class Scraper
                     "," + (item.CommunityRating ?? -1).ToString(CultureInfo.InvariantCulture) +
                     "," + SanitizeDbItem(eventType) +
                     "," + SanitizeDbItem(item!.LibraryId) +
+                    "," + SanitizeDbItem(item.Genres) +
                 ");");
     }
 
@@ -428,7 +429,8 @@ public class Scraper
             $"CommunityRating={(item.CommunityRating ?? -1).ToString(CultureInfo.InvariantCulture)}, " +
             $"RunTime={item.RunTime}, " +
             $"PremiereYear={SanitizeDbItem(item.PremiereYear)}, " +
-            $"PosterPath={SanitizeDbItem(item.PosterPath)} " +
+            $"PosterPath={SanitizeDbItem(item.PosterPath)}, " +
+            $"Genres={SanitizeDbItem(item.Genres)} " +
             $"WHERE Filename={sanitizedFilename};");
 
         logger.Info($"Updated metadata for '{item.Title}' in {table}");
@@ -568,7 +570,8 @@ public class Scraper
         currFileObj.CommunityRating = series.CommunityRating;
         currFileObj.ItemID = series.Id.ToString("N");
         currFileObj.LibraryId = GetLibraryId(episode);
-        
+        currFileObj.Genres = series.Genres != null ? string.Join(", ", series.Genres) : string.Empty;
+
         if (episode.IndexNumber is int && episode.IndexNumber is not null)
         {
             currFileObj.Episode = (int)episode.IndexNumber;

--- a/Jellyfin.Plugin.Newsletters/Shared/Database/SQLiteDatabase.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/Database/SQLiteDatabase.cs
@@ -114,6 +114,7 @@ public class SQLiteDatabase
             new_cols.Add("CommunityRating", "REAL");
             new_cols.Add("EventType", "TEXT");
             new_cols.Add("LibraryId", "TEXT");
+            new_cols.Add("Genres", "TEXT");
 
             var existingColumns = GetTableColumns(table);
 

--- a/Jellyfin.Plugin.Newsletters/Shared/Entities/JsonFileObj.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/Entities/JsonFileObj.cs
@@ -30,6 +30,7 @@ public class JsonFileObj
         EventType = string.Empty;
         ExternalIds = new Dictionary<string, string>();
         LibraryId = string.Empty;
+        Genres = string.Empty;
     }
 
     /// <summary>
@@ -113,6 +114,11 @@ public class JsonFileObj
     public Dictionary<string, string> ExternalIds { get; }
 
     /// <summary>
+    /// Gets or sets the genres of the item.
+    /// </summary>
+    public string Genres { get; set; }
+
+    /// <summary>
     /// Converts a database row to a <see cref="JsonFileObj"/> instance.
     /// </summary>
     /// <param name="row">The database row as a list of <see cref="ResultSetValue"/>.</param>
@@ -135,7 +141,8 @@ public class JsonFileObj
             OfficialRating = row[11].ToString(),
             CommunityRating = string.IsNullOrEmpty(row[12].ToString()) ? 0.0f : float.Parse(row[12].ToString(), CultureInfo.InvariantCulture),
             EventType = row[13].ToString(),
-            LibraryId = row[14].ToString()
+            LibraryId = row[14].ToString(),
+            Genres = row[15].ToString()
         };
 
         return obj;
@@ -163,6 +170,7 @@ public class JsonFileObj
         item_dict.Add("{CommunityRating}", this.CommunityRating);
         item_dict.Add("{EventType}", this.EventType);
         item_dict.Add("{LibraryId}", this.LibraryId);
+        item_dict.Add("{Genres}", this.Genres);
 
         return item_dict;
     }
@@ -187,7 +195,8 @@ public class JsonFileObj
             PremiereYear = "2025",
             RunTime = 60,
             OfficialRating = "TV-14",
-            CommunityRating = 8.413f
+            CommunityRating = 8.413f,
+            Genres = "Action, Drama"
         };
 
         return obj;


### PR DESCRIPTION
This PR closes #89 and contains the following changes:

- New Genres column for the database.
- `{Genres}` tag is available for HTML clients (Email, Matrix) - add it to your template where needed.
- Discord and Telegram configs each have a toggle to enable/disable genres in the newsletter. On Discord it appears as an inline embed field; on Telegram it appears in the message text.

Note: Genres are disabled by default for Discord and Telegram. HTML templates do not include `{Genres}` by default, users can add it manually to their custom templates.