### PR TITLE
Introducing max items per section for each client

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Clients/Discord/EmbedBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Discord/EmbedBuilder.cs
@@ -48,11 +48,33 @@ public class EmbedBuilder(
             // Open connection for ParseSeriesInfo calls inside the item loop
             Db.CreateConnection();
 
+            int maxItemsPerSection = discordConfig.MaxItemsPerSection;
+            var sectionItemCounts = new Dictionary<string, int>();
+
             // Build embeds from sorted items
             foreach (var item in sortedItems)
             {
                 string eventType = item.EventType?.ToLowerInvariant() ?? "add";
                 string libraryName = eventType == "upcoming" ? (item.LibraryId ?? string.Empty) : GetLibraryName(item.LibraryId, libraryNameMap);
+
+                // Skip items beyond the per-section cap
+                if (maxItemsPerSection > 0)
+                {
+                    string sectionKey = $"{eventType}|{libraryName}";
+                    sectionItemCounts.TryGetValue(sectionKey, out int sectionItemCount);
+                    sectionItemCounts[sectionKey] = sectionItemCount + 1;
+
+                    if (sectionItemCount >= maxItemsPerSection)
+                    {
+                        // Log once per section, when the cap is first crossed
+                        if (sectionItemCount == maxItemsPerSection)
+                        {
+                            Logger.Debug($"Truncating section - Event: {eventType}, Library: {libraryName}, Max items: {maxItemsPerSection}");
+                        }
+
+                        continue;
+                    }
+                }
 
                 int embedColor = GetEventColor(item.EventType, item.Type, discordConfig);
                 var fieldsList = new Collection<EmbedField>();

--- a/Jellyfin.Plugin.Newsletters/Clients/Email/HTMLBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Email/HTMLBuilder.cs
@@ -151,7 +151,19 @@ public class HtmlBuilder(
         string serverId,
         EmailConfiguration config)
     {
-        foreach (var item in items)
+        int maxItemsPerSection = config.MaxItemsPerSection;
+
+        // Drop overflow items up front (also skips image resizing for them)
+        IReadOnlyList<JsonFileObj> itemsToProcess = items;
+        bool overflowed = false;
+        if (maxItemsPerSection > 0 && items.Count > maxItemsPerSection)
+        {
+            Logger.Debug($"Truncating section - Event: {eventType}, Library: {libraryName}, Items: {items.Count} -> {maxItemsPerSection}");
+            itemsToProcess = items.Take(maxItemsPerSection).ToList();
+            overflowed = true;
+        }
+
+        foreach (var item in itemsToProcess)
         {
             // Track image size if needed
             int entryImageBytes = 0;
@@ -191,6 +203,26 @@ public class HtmlBuilder(
             currentChunkImages.Add(imgToAdd);
             currentChunkBytes += entryBytes;
         }
+
+        if (overflowed)
+        {
+            string notice = BuildOverflowNoticeHtml();
+            currentChunkBuilder.Append(notice);
+            currentChunkBytes += Encoding.UTF8.GetByteCount(notice);
+        }
+    }
+
+    /// <summary>
+    /// Builds a plain "…" line shown after a truncated section.
+    /// Wrapped in a table row when the active entry template is itself a table row
+    /// (the built-in templates are), so it renders predictably inside the body table.
+    /// </summary>
+    private string BuildOverflowNoticeHtml()
+    {
+        const string Notice = "<div style='padding: 12px 10px 20px 10px; text-align: center; color: #9E9E9E; font-size: 1.5em;'>&#8230;</div>";
+        return GetEntryHtml().TrimStart().StartsWith("<tr", StringComparison.OrdinalIgnoreCase)
+            ? $"<tr><td colspan='2'>{Notice}</td></tr>"
+            : Notice;
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixMessageBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixMessageBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -48,6 +49,8 @@ public class MatrixMessageBuilder(
             // Open connection for ParseSeriesInfo calls inside BuildEntryHtml
             Db.CreateConnection();
 
+            int maxItemsPerSection = config.MaxItemsPerSection;
+
             foreach (var eventGroup in groupedItems)
             {
                 foreach (var library in eventGroup.Libraries)
@@ -59,9 +62,17 @@ public class MatrixMessageBuilder(
 
                     contentBuilderHtml.Append(GetEventSectionHeader(eventGroup.EventType, library.LibraryName));
 
-                    foreach (var item in library.Items)
+                    // Drop overflow items beyond the per-section cap
+                    bool overflowed = maxItemsPerSection > 0 && library.Items.Count > maxItemsPerSection;
+                    foreach (var item in overflowed ? library.Items.Take(maxItemsPerSection) : library.Items)
                     {
                         contentBuilderHtml.Append(BuildEntryHtml(item, eventGroup.EventType, serverId));
+                    }
+
+                    if (overflowed)
+                    {
+                        Logger.Debug($"Truncating section - Event: {eventGroup.EventType}, Library: {library.LibraryName}, Items: {library.Items.Count} -> {maxItemsPerSection}");
+                        contentBuilderHtml.Append("<div>&#8230;</div>");
                     }
                 }
             }

--- a/Jellyfin.Plugin.Newsletters/Clients/Telegram/TelegramMessageBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Telegram/TelegramMessageBuilder.cs
@@ -71,11 +71,34 @@ public class TelegramMessageBuilder(
             // Open connection for ParseSeriesInfo calls inside BuildMessageText
             Db.CreateConnection();
 
+            int maxItemsPerSection = telegramConfig.MaxItemsPerSection;
+            var sectionItemCounts = new Dictionary<string, int>();
+
             // Build messages from sorted items
             foreach (var item in sortedItems)
             {
                 string eventType = item.EventType?.ToLowerInvariant() ?? "add";
                 string libraryName = eventType == "upcoming" ? (item.LibraryId ?? string.Empty) : GetLibraryName(item.LibraryId, libraryNameMap);
+
+                // Skip items beyond the per-section cap
+                if (maxItemsPerSection > 0)
+                {
+                    string sectionKey = $"{eventType}|{libraryName}";
+                    sectionItemCounts.TryGetValue(sectionKey, out int sectionItemCount);
+                    sectionItemCounts[sectionKey] = sectionItemCount + 1;
+
+                    if (sectionItemCount >= maxItemsPerSection)
+                    {
+                        // Log once per section, when the cap is first crossed
+                        if (sectionItemCount == maxItemsPerSection)
+                        {
+                            Logger.Debug($"Truncating section - Event: {eventType}, Library: {libraryName}, Max items: {maxItemsPerSection}");
+                        }
+
+                        continue;
+                    }
+                }
+
                 var messageText = BuildMessageText(item, systemId, telegramConfig, libraryName);
                     
                 string? imageUrl = null;

--- a/Jellyfin.Plugin.Newsletters/Configuration/DiscordConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/DiscordConfiguration.cs
@@ -127,4 +127,10 @@ public class DiscordConfiguration : INewsletterConfiguration
     /// Gets or sets a value indicating whether to include upcoming items in the newsletter.
     /// </summary>
     public bool NewsletterOnUpcomingItemEnabled { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the maximum number of items shown per newsletter section.
+    /// A value of 0 means unlimited (default).
+    /// </summary>
+    public int MaxItemsPerSection { get; set; } = 0;
 }

--- a/Jellyfin.Plugin.Newsletters/Configuration/EmailConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/EmailConfiguration.cs
@@ -124,4 +124,10 @@ public class EmailConfiguration : ITemplatedConfiguration
     /// Gets or sets a value indicating whether authentication is used for the SMTP connection.
     /// </summary>
     public bool UseAuthentication { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum number of items shown per newsletter section.
+    /// A value of 0 means unlimited (default).
+    /// </summary>
+    public int MaxItemsPerSection { get; set; } = 0;
 }

--- a/Jellyfin.Plugin.Newsletters/Configuration/INewsletterConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/INewsletterConfiguration.cs
@@ -41,4 +41,10 @@ public interface INewsletterConfiguration
     /// Gets a value indicating whether to include upcoming items in the newsletter.
     /// </summary>
     bool NewsletterOnUpcomingItemEnabled { get; }
+
+    /// <summary>
+    /// Gets the maximum number of items shown per newsletter section.
+    /// A value of 0 means unlimited.
+    /// </summary>
+    int MaxItemsPerSection { get; }
 }

--- a/Jellyfin.Plugin.Newsletters/Configuration/MatrixConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/MatrixConfiguration.cs
@@ -59,21 +59,39 @@ public class MatrixConfiguration : ITemplatedConfiguration
     /// </summary>
     public string Header { get; set; } = string.Empty;
 
-    /// <inheritdoc/>
-    public Collection<string> SelectedSeriesLibraries { get; set; } = new();
+    /// <summary>
+    /// Gets or sets the collection of selected series libraries.
+    /// </summary>
+    public Collection<string> SelectedSeriesLibraries { get; set; } = new Collection<string>();
 
-    /// <inheritdoc/>
-    public Collection<string> SelectedMoviesLibraries { get; set; } = new();
+    /// <summary>
+    /// Gets or sets the collection of selected movies libraries.
+    /// </summary>
+    public Collection<string> SelectedMoviesLibraries { get; set; } = new Collection<string>();
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Gets or sets a value indicating whether to send newsletter on item added.
+    /// </summary>
     public bool NewsletterOnItemAddedEnabled { get; set; } = true;
 
-    /// <inheritdoc/>
-    public bool NewsletterOnItemUpdatedEnabled { get; set; }
+    /// <summary>
+    /// Gets or sets a value indicating whether to send newsletter on item updated.
+    /// </summary>
+    public bool NewsletterOnItemUpdatedEnabled { get; set; } = false;
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Gets or sets a value indicating whether to send newsletter on item deleted.
+    /// </summary>
     public bool NewsletterOnItemDeletedEnabled { get; set; } = true;
 
-    /// <inheritdoc/>
-    public bool NewsletterOnUpcomingItemEnabled { get; set; }
+    /// <summary>
+    /// Gets or sets a value indicating whether to include upcoming items in the newsletter.
+    /// </summary>
+    public bool NewsletterOnUpcomingItemEnabled { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the maximum number of items shown per newsletter section.
+    /// A value of 0 means unlimited (default).
+    /// </summary>
+    public int MaxItemsPerSection { get; set; } = 0;
 }

--- a/Jellyfin.Plugin.Newsletters/Configuration/TelegramConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/TelegramConfiguration.cs
@@ -97,4 +97,10 @@ public class TelegramConfiguration : INewsletterConfiguration
     /// Gets or sets a value indicating whether to include upcoming items in the newsletter.
     /// </summary>
     public bool NewsletterOnUpcomingItemEnabled { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the maximum number of items shown per newsletter section.
+    /// A value of 0 means unlimited (default).
+    /// </summary>
+    public int MaxItemsPerSection { get; set; } = 0;
 }

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -702,6 +702,16 @@
                 return html;
             }
 
+            function getMaxItemsHtml(clientId, configType, maxItems) {
+                var updateFn = 'update' + (configType.charAt(0).toUpperCase() + configType.slice(1)) + 'ConfigFromUI(\'' + clientId + '\')';
+                var html = '<div class="inputContainer">';
+                html += '  <label class="inputLabel inputLabelUnfocused">Max Items Per Section:</label>';
+                html += '  <input id="' + configType + '-max-items-' + clientId + '" type="number" is="emby-input" min="0" value="' + (maxItems || 0) + '" onchange="' + updateFn + '" />';
+                html += '  <div class="fieldDescription">Limit how many items are shown in each section of the newsletter (for example, "Added to Movies"). Items beyond this limit are left out of the newsletter entirely (they are not sent, just skipped). Set to 0 to show all items.</div>';
+                html += '</div>';
+                return html;
+            }
+
             // ===================== DISCORD CONFIG FUNCTIONS =====================
 
             function addDiscordConfig() {
@@ -729,7 +739,8 @@
                     NewsletterOnItemAddedEnabled: true,
                     NewsletterOnItemUpdatedEnabled: false,
                     NewsletterOnItemDeletedEnabled: true,
-                    NewsletterOnUpcomingItemEnabled: false
+                    NewsletterOnUpcomingItemEnabled: false,
+                    MaxItemsPerSection: 0
                 };
                 discordConfigs.push(newConfig);
                 renderDiscordConfigs();
@@ -790,6 +801,7 @@
                 config.MoviesAddEmbedColor = document.getElementById('discord-movies-add-color-' + id).value;
                 config.MoviesDeleteEmbedColor = document.getElementById('discord-movies-delete-color-' + id).value;
                 config.MoviesUpdateEmbedColor = document.getElementById('discord-movies-update-color-' + id).value;
+                config.MaxItemsPerSection = Math.max(0, parseInt(document.getElementById('discord-max-items-' + id).value) || 0);
 
                 // Update Event Toggles
                 config.NewsletterOnItemAddedEnabled = document.getElementById('discord-event-add-' + id).checked;
@@ -849,6 +861,7 @@
                     html += '    </div>';
                     html += getLibrarySelectionHtml(config.Id, 'discord', config.SelectedSeriesLibraries, config.SelectedMoviesLibraries);
                     html += getEventTogglesHtml(config.Id, 'discord', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled);
+                    html += getMaxItemsHtml(config.Id, 'discord', config.MaxItemsPerSection);
                     html += '    <div>';
                     html += '      <label class="inputLabel">Message Fields:</label>';
                     html += '      <table><tr>';
@@ -906,7 +919,8 @@
                     NewsletterOnItemAddedEnabled: true,
                     NewsletterOnItemUpdatedEnabled: false,
                     NewsletterOnItemDeletedEnabled: true,
-                    NewsletterOnUpcomingItemEnabled: false
+                    NewsletterOnUpcomingItemEnabled: false,
+                    MaxItemsPerSection: 0
                 };
                 telegramConfigs.push(newConfig);
                 renderTelegramConfigs();
@@ -961,6 +975,7 @@
                 config.DurationEnabled = document.getElementById('telegram-duration-' + id).checked;
                 config.EpisodesEnabled = document.getElementById('telegram-episodes-' + id).checked;
                 config.GenresEnabled = document.getElementById('telegram-genres-' + id).checked;
+                config.MaxItemsPerSection = Math.max(0, parseInt(document.getElementById('telegram-max-items-' + id).value) || 0);
 
                 // Update Event Toggles
                 config.NewsletterOnItemAddedEnabled = document.getElementById('telegram-event-add-' + id).checked;
@@ -1020,6 +1035,7 @@
                     html += '    </div>';
                     html += getLibrarySelectionHtml(config.Id, 'telegram', config.SelectedSeriesLibraries, config.SelectedMoviesLibraries);
                     html += getEventTogglesHtml(config.Id, 'telegram', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled);
+                    html += getMaxItemsHtml(config.Id, 'telegram', config.MaxItemsPerSection);
                     html += '    <div>';
                     html += '      <label class="inputLabel">Message Fields:</label>';
                     html += '      <table><tr>';
@@ -1065,7 +1081,8 @@
                     NewsletterOnItemDeletedEnabled: true,
                     NewsletterOnUpcomingItemEnabled: false,
                     EnableSsl: true,
-                    UseAuthentication: true
+                    UseAuthentication: true,
+                    MaxItemsPerSection: 0
                 };
                 emailConfigs.push(newConfig);
                 renderEmailConfigs();
@@ -1125,6 +1142,7 @@
                 config.TemplateCategory = document.getElementById('email-category-' + id).value;
                 config.EnableSsl = document.getElementById('email-ssl-' + id).checked;
                 config.UseAuthentication = document.getElementById('email-auth-' + id).checked;
+                config.MaxItemsPerSection = Math.max(0, parseInt(document.getElementById('email-max-items-' + id).value) || 0);
 
                 // Update Event Toggles
                 config.NewsletterOnItemAddedEnabled = document.getElementById('email-event-add-' + id).checked;
@@ -1228,6 +1246,7 @@
                     html += '    </div>';
                     html += getLibrarySelectionHtml(config.Id, 'email', config.SelectedSeriesLibraries, config.SelectedMoviesLibraries);
                     html += getEventTogglesHtml(config.Id, 'email', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled);
+                    html += getMaxItemsHtml(config.Id, 'email', config.MaxItemsPerSection);
                     html += '    <div class="inputContainer">';
                     html += '      <label class="selectLabel" for="email-category-' + config.Id + '">Template Category:</label>';
                     html += '      <select id="email-category-' + config.Id + '" is="emby-select" onchange="updateEmailConfigFromUI(\'' + config.Id + '\')" class="emby-select-withcolor emby-select">';
@@ -1277,7 +1296,8 @@
                     NewsletterOnItemAddedEnabled: true,
                     NewsletterOnItemUpdatedEnabled: false,
                     NewsletterOnItemDeletedEnabled: true,
-                    NewsletterOnUpcomingItemEnabled: false
+                    NewsletterOnUpcomingItemEnabled: false,
+                    MaxItemsPerSection: 0
                 };
                 matrixConfigs.push(newConfig);
                 renderMatrixConfigs();
@@ -1328,6 +1348,7 @@
                 config.Entry = document.getElementById('matrix-entry-' + id).value;
                 config.Header = document.getElementById('matrix-header-' + id).value;
                 config.TemplateCategory = document.getElementById('matrix-category-' + id).value;
+                config.MaxItemsPerSection = Math.max(0, parseInt(document.getElementById('matrix-max-items-' + id).value) || 0);
 
                 config.NewsletterOnItemAddedEnabled = document.getElementById('matrix-event-add-' + id).checked;
                 config.NewsletterOnItemUpdatedEnabled = document.getElementById('matrix-event-update-' + id).checked;
@@ -1389,6 +1410,7 @@
                     html += '    </div>';
                     html += getLibrarySelectionHtml(config.Id, 'matrix', config.SelectedSeriesLibraries, config.SelectedMoviesLibraries);
                     html += getEventTogglesHtml(config.Id, 'matrix', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled);
+                    html += getMaxItemsHtml(config.Id, 'matrix', config.MaxItemsPerSection);
                     html += '    <div class="inputContainer">';
                     html += '      <label class="selectLabel" for="matrix-category-' + config.Id + '">Template Category:</label>';
                     html += '      <select id="matrix-category-' + config.Id + '" is="emby-select" onchange="updateMatrixConfigFromUI(\'' + config.Id + '\')" class="emby-select-withcolor emby-select">';

--- a/README.md
+++ b/README.md
@@ -266,6 +266,10 @@ Manifest is up and running! You can now import the manifest in Jellyfin and this
   - **Delete**: Enable deleted items section in the newsletter (default: enabled).
   - **Upcoming**: Enable upcoming media section in the newsletter, sourced from Radarr/Sonarr (default: disabled).
 
+### Max Items Per Section
+
+- Limit how many items are shown in each section of the newsletter (for example, "Added to Movies"). Items beyond the limit are left out of the newsletter entirely (they are not sent, just skipped), and a small "…" note is shown at the end of the section. Set to 0 to show all items (default).
+
 ### Newsletter Template Category
 
 You can select between different email templates:
@@ -317,6 +321,10 @@ You can select between different email templates:
   - **Delete**: Enable deleted items section in the newsletter (default: enabled).
   - **Upcoming**: Enable upcoming media section in the newsletter, sourced from Radarr/Sonarr (default: disabled).
 
+### Max Items Per Section
+
+- Limit how many items are shown in each section of the newsletter (for example, "Added to Movies"). Items beyond the limit are left out of the newsletter entirely (they are not sent, just skipped). Set to 0 to show all items (default).
+
 ### Fields & Color selection
 
 - Select the fields that you want as part of your embed.
@@ -348,6 +356,10 @@ You can select between different email templates:
   - **Update**: Enable updated items section in the newsletter. Updates are detected when media files are upgraded (e.g., by tools like Radarr/Sonarr), where the old file is deleted and a new one is added with the same title/season/episode information (default: disabled).
   - **Delete**: Enable deleted items section in the newsletter (default: enabled).
   - **Upcoming**: Enable upcoming media section in the newsletter, sourced from Radarr/Sonarr (default: disabled).
+
+### Max Items Per Section
+
+- Limit how many items are shown in each section of the newsletter (for example, "Added to Movies"). Items beyond the limit are left out of the newsletter entirely (they are not sent, just skipped). Set to 0 to show all items (default).
 
 ### Fields selection
 
@@ -386,6 +398,10 @@ You can select between different email templates:
   - **Update**: Enable updated items section in the newsletter. Updates are detected when media files are upgraded (e.g., by tools like Radarr/Sonarr), where the old file is deleted and a new one is added with the same title/season/episode information (default: disabled).
   - **Delete**: Enable deleted items section in the newsletter (default: enabled).
   - **Upcoming**: Enable upcoming media section in the newsletter, sourced from Radarr/Sonarr (default: disabled).
+
+### Max Items Per Section
+
+- Limit how many items are shown in each section of the newsletter (for example, "Added to Movies"). Items beyond the limit are skipped and a small "…" note is shown at the end of the section. Set to 0 to show all items (default).
 
 ### Newsletter Template Category
 


### PR DESCRIPTION
This PR closes [#85](https://github.com/Sanidhya30/Jellyfin-Newsletter/issues/85) and contains the following changes:

* New `Max Items Per Section` setting available for every client (Email, Discord, Telegram, Matrix), configurable per client instance.
* Limits how many items are shown in each section of the newsletter (a section being a library + event type combination, e.g. "Added to Movies"). Items beyond the limit are left out of the newsletter entirely.
* On Email and Matrix a small `…` line is appended to any section that was truncated; on Discord and Telegram the extra items are simply not sent.
* Debug logging when a section is truncated, so it is clear from the logs why items were left out.

Note: The setting defaults to `0` (unlimited) for all clients, so existing newsletters are unaffected unless the limit is explicitly configured.