### PR TITLE
Add a Preview tab to see and edit the next newsletter before it sends

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Clients/Client.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Client.cs
@@ -85,7 +85,7 @@ public class Client(Logger loggerInstance,
         {
             Db.CreateConnection();
 
-            foreach (var row in Db.Query("SELECT COUNT(*) FROM CurrNewsletterData;"))
+            foreach (var row in Db.Query("SELECT COUNT(*) FROM CurrNewsletterData WHERE " + SQLiteDatabase.NotExcludedClause + ";"))
             {
                 if (row is not null)
                 {

--- a/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
@@ -45,27 +45,6 @@ public class ClientBuilder(Logger loggerInstance,
     protected ILibraryManager LibraryManager { get; } = libraryManagerInstance;
 
     /// <summary>
-    /// Builds a dictionary mapping LibraryId to LibraryName using the Jellyfin library manager.
-    /// </summary>
-    /// <returns>A dictionary mapping library IDs to library names.</returns>
-    protected Dictionary<string, string> BuildLibraryNameMap()
-    {
-        return LibraryNames.BuildMap(LibraryManager, Logger);
-    }
-
-    /// <summary>
-    /// Gets the library name for a given library ID using the provided map.
-    /// Falls back to "Library" if the ID is not found.
-    /// </summary>
-    /// <param name="libraryId">The library ID to look up.</param>
-    /// <param name="libraryNameMap">The dictionary mapping library IDs to names.</param>
-    /// <returns>The library name, or "Library" if not found.</returns>
-    protected static string GetLibraryName(string? libraryId, Dictionary<string, string> libraryNameMap)
-    {
-        return LibraryNames.Resolve(libraryId, libraryNameMap);
-    }
-
-    /// <summary>
     /// Queries newsletter data from the database, merges upcoming items, deduplicates,
     /// and sorts by event type → media type → library name.
     /// This is the shared data pipeline used by all client builders.
@@ -76,7 +55,7 @@ public class ClientBuilder(Logger loggerInstance,
     /// <returns>A sorted, deduplicated list of items ready for rendering.</returns>
     protected IReadOnlyList<JsonFileObj> BuildSortedItems(INewsletterConfiguration config, IReadOnlyList<JsonFileObj> upcomingItems, string clientName)
     {
-        var libraryNameMap = BuildLibraryNameMap();
+        var libraryNameMap = LibraryNames.BuildMap(LibraryManager, Logger);
         var itemsByKey = new Dictionary<string, JsonFileObj>();
 
         try
@@ -137,7 +116,7 @@ public class ClientBuilder(Logger loggerInstance,
         return allItems
             .OrderBy(i => eventTypeOrder.GetValueOrDefault(i.EventType?.ToLowerInvariant() ?? "add", 0))
             .ThenBy(i => i.Type == "Movie" ? 0 : 1)
-            .ThenBy(i => i.EventType == "upcoming" ? i.LibraryId : GetLibraryName(i.LibraryId, libraryNameMap))
+            .ThenBy(i => i.EventType == "upcoming" ? i.LibraryId : LibraryNames.Resolve(i.LibraryId, libraryNameMap))
             .ToList();
     }
 

--- a/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Jellyfin.Plugin.Newsletters.Configuration;
+using Jellyfin.Plugin.Newsletters.Shared;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
 using Jellyfin.Plugin.Newsletters.Shared.Entities;
 using MediaBrowser.Controller.Library;
@@ -49,24 +50,7 @@ public class ClientBuilder(Logger loggerInstance,
     /// <returns>A dictionary mapping library IDs to library names.</returns>
     protected Dictionary<string, string> BuildLibraryNameMap()
     {
-        var map = new Dictionary<string, string>();
-        try
-        {
-            var virtualFolders = LibraryManager.GetVirtualFolders();
-            foreach (var folder in virtualFolders)
-            {
-                if (!string.IsNullOrEmpty(folder.ItemId) && !map.ContainsKey(folder.ItemId))
-                {
-                    map[folder.ItemId] = folder.Name;
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.Error($"Error building library name map: {ex.Message}");
-        }
-
-        return map;
+        return LibraryNames.BuildMap(LibraryManager, Logger);
     }
 
     /// <summary>
@@ -78,12 +62,7 @@ public class ClientBuilder(Logger loggerInstance,
     /// <returns>The library name, or "Library" if not found.</returns>
     protected static string GetLibraryName(string? libraryId, Dictionary<string, string> libraryNameMap)
     {
-        if (!string.IsNullOrEmpty(libraryId) && libraryNameMap.TryGetValue(libraryId, out var name))
-        {
-            return name;
-        }
-
-        return "Library";
+        return LibraryNames.Resolve(libraryId, libraryNameMap);
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
@@ -83,7 +83,7 @@ public class ClientBuilder(Logger loggerInstance,
         {
             Db.CreateConnection();
 
-            foreach (var row in Db.Query("SELECT * FROM CurrNewsletterData;"))
+            foreach (var row in Db.Query("SELECT * FROM CurrNewsletterData WHERE " + SQLiteDatabase.NotExcludedClause + ";"))
             {
                 if (row is not null)
                 {
@@ -173,7 +173,7 @@ public class ClientBuilder(Logger loggerInstance,
         else
         {
             // Query by title and event type to avoid conflicts when same title exists with different events
-            foreach (var row in Db.Query("SELECT * FROM CurrNewsletterData WHERE Title='" + currObj.Title.Replace("'", "''", StringComparison.Ordinal) + "' AND EventType='" + currObj.EventType.Replace("'", "''", StringComparison.Ordinal) + "';"))
+            foreach (var row in Db.Query("SELECT * FROM CurrNewsletterData WHERE Title='" + currObj.Title.Replace("'", "''", StringComparison.Ordinal) + "' AND EventType='" + currObj.EventType.Replace("'", "''", StringComparison.Ordinal) + "' AND " + SQLiteDatabase.NotExcludedClause + ";"))
             {
                 if (row is not null)
                 {

--- a/Jellyfin.Plugin.Newsletters/Clients/Discord/EmbedBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Discord/EmbedBuilder.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using Jellyfin.Plugin.Newsletters.Configuration;
 using Jellyfin.Plugin.Newsletters.Integrations;
+using Jellyfin.Plugin.Newsletters.Shared;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
 using Jellyfin.Plugin.Newsletters.Shared.Entities;
 using MediaBrowser.Controller.Library;
@@ -38,7 +39,7 @@ public class EmbedBuilder(
         var result = new List<(Embed, MemoryStream?, string)>();
 
         // Build library name map
-        var libraryNameMap = BuildLibraryNameMap();
+        var libraryNameMap = LibraryNames.BuildMap(LibraryManager, Logger);
 
         // BuildSortedItems manages its own DB connection for querying/deduplication
         var sortedItems = BuildSortedItems(discordConfig, upcomingItems, "Discord");
@@ -55,7 +56,7 @@ public class EmbedBuilder(
             foreach (var item in sortedItems)
             {
                 string eventType = item.EventType?.ToLowerInvariant() ?? "add";
-                string libraryName = eventType == "upcoming" ? (item.LibraryId ?? string.Empty) : GetLibraryName(item.LibraryId, libraryNameMap);
+                string libraryName = eventType == "upcoming" ? (item.LibraryId ?? string.Empty) : LibraryNames.Resolve(item.LibraryId, libraryNameMap);
 
                 // Skip items beyond the per-section cap
                 if (maxItemsPerSection > 0)

--- a/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Jellyfin.Plugin.Newsletters.Configuration;
 using Jellyfin.Plugin.Newsletters.Integrations;
+using Jellyfin.Plugin.Newsletters.Shared;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
 using Jellyfin.Plugin.Newsletters.Shared.Entities;
 using MediaBrowser.Controller.Library;
@@ -241,7 +242,7 @@ public abstract class HtmlContentBuilder(
     /// <returns>The grouped items structure.</returns>
     protected IEnumerable<EventGroupResult> BuildGroupedItems(INewsletterConfiguration config, string clientName)
     {
-        var libraryNameMap = BuildLibraryNameMap();
+        var libraryNameMap = LibraryNames.BuildMap(LibraryManager, Logger);
         var sortedItems = BuildSortedItems(config, UpcomingItems, clientName);
 
         return sortedItems
@@ -250,7 +251,7 @@ public abstract class HtmlContentBuilder(
             {
                 EventType = eventGroup.Key,
                 Libraries = eventGroup
-                    .GroupBy(i => i.EventType == "upcoming" ? i.LibraryId : GetLibraryName(i.LibraryId, libraryNameMap))
+                    .GroupBy(i => i.EventType == "upcoming" ? i.LibraryId : LibraryNames.Resolve(i.LibraryId, libraryNameMap))
                     .Select(libGroup => new LibraryGroupResult { LibraryName = libGroup.Key, Items = libGroup.ToList() })
             });
     }

--- a/Jellyfin.Plugin.Newsletters/Clients/Telegram/TelegramMessageBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Telegram/TelegramMessageBuilder.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using Jellyfin.Plugin.Newsletters.Configuration;
 using Jellyfin.Plugin.Newsletters.Integrations;
+using Jellyfin.Plugin.Newsletters.Shared;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
 using Jellyfin.Plugin.Newsletters.Shared.Entities;
 using MediaBrowser.Controller.Library;
@@ -61,7 +62,7 @@ public class TelegramMessageBuilder(
         var result = new List<(string, string?, MemoryStream?, string)>();
 
         // Build library name map
-        var libraryNameMap = BuildLibraryNameMap();
+        var libraryNameMap = LibraryNames.BuildMap(LibraryManager, Logger);
 
         // BuildSortedItems manages its own DB connection for querying/deduplication
         var sortedItems = BuildSortedItems(telegramConfig, upcomingItems, "Telegram");
@@ -78,7 +79,7 @@ public class TelegramMessageBuilder(
             foreach (var item in sortedItems)
             {
                 string eventType = item.EventType?.ToLowerInvariant() ?? "add";
-                string libraryName = eventType == "upcoming" ? (item.LibraryId ?? string.Empty) : GetLibraryName(item.LibraryId, libraryNameMap);
+                string libraryName = eventType == "upcoming" ? (item.LibraryId ?? string.Empty) : LibraryNames.Resolve(item.LibraryId, libraryNameMap);
 
                 // Skip items beyond the per-section cap
                 if (maxItemsPerSection > 0)

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -1702,7 +1702,7 @@
                             var isEpisode = group.Type !== 'Movie' && item.Season >= 0 && item.Episode >= 0;
                             var label = isEpisode
                                 ? 'S' + ('0' + item.Season).slice(-2) + 'E' + ('0' + item.Episode).slice(-2)
-                                : item.Filename.split('/').pop();
+                                : item.Filename.split(/[\\/]/).pop();
 
                             html += '<div class="preview-episode' + (item.Excluded ? ' preview-excluded' : '') + '"'
                                 + ' data-preview-file="' + escapeHtml(item.Filename) + '">';

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -16,6 +16,7 @@
                     <div class="tab-bar">
                         <button type="button" class="tab-link active"
                             onclick="openTab(event, 'General')">General</button>
+                        <button type="button" class="tab-link" onclick="openTab(event, 'Preview')">Preview</button>
                         <button type="button" class="tab-link" onclick="openTab(event, 'Email')">Email</button>
                         <button type="button" class="tab-link" onclick="openTab(event, 'Discord')">Discord</button>
                         <button type="button" class="tab-link" onclick="openTab(event, 'Telegram')">Telegram</button>
@@ -130,6 +131,29 @@
                                 <p class="no-configs-text">No Sonarr instances configured. Click "Add Sonarr Instance"
                                     to create one.</p>
                             </div>
+                        </div>
+                    </div>
+
+                    <!-- Preview Tab -->
+                    <div id="Preview" class="tab-content">
+                        <div class="config-header">
+                            <h3>Next Newsletter</h3>
+                            <button type="button" is="emby-button" class="raised button-submit"
+                                onclick="loadPreview()">
+                                <span>Refresh</span>
+                            </button>
+                        </div>
+                        <div class="fieldDescription" style="margin-bottom: 15px;">
+                            Everything queued for the next newsletter. Removing an entry here excludes it
+                            from every client and takes effect immediately &mdash; you do not need to press Save.
+                            Excluded entries can be restored until the newsletter sends.
+                            <br>
+                            Upcoming items from Radarr/Sonarr are fetched live when the newsletter is built and
+                            are not listed here.
+                        </div>
+                        <div id="PreviewSummary" class="fieldDescription" style="margin-bottom: 10px;"></div>
+                        <div id="PreviewList" class="config-list">
+                            <p class="no-configs-text">Loading&hellip;</p>
                         </div>
                     </div>
 
@@ -414,6 +438,98 @@
             .config-field-row>.inputContainer {
                 flex: 1;
                 min-width: 200px;
+            }
+
+            /* Preview Tab */
+            .preview-group {
+                border: 1px solid #444;
+                border-radius: 4px;
+                margin-bottom: 8px;
+            }
+
+            .preview-group-header {
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                padding: 10px 12px;
+                cursor: pointer;
+            }
+
+            .preview-group .expand-icon {
+                transition: transform 0.3s;
+                display: inline-block;
+                width: 1em;
+            }
+
+            .preview-group.expanded .expand-icon {
+                transform: rotate(90deg);
+            }
+
+            .preview-title {
+                flex: 1;
+                min-width: 0;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            .preview-meta {
+                opacity: 0.7;
+                font-size: 0.85em;
+                white-space: nowrap;
+            }
+
+            .preview-badge {
+                border-radius: 3px;
+                padding: 2px 7px;
+                font-size: 0.72em;
+                text-transform: uppercase;
+                letter-spacing: 0.04em;
+                color: #fff;
+            }
+
+            .preview-badge.add {
+                background: #2e7d32;
+            }
+
+            .preview-badge.update {
+                background: #1565c0;
+            }
+
+            .preview-badge.delete {
+                background: #c62828;
+            }
+
+            .preview-episodes {
+                display: none;
+                border-top: 1px solid #444;
+                padding: 6px 12px 10px 12px;
+            }
+
+            .preview-group.expanded .preview-episodes {
+                display: block;
+            }
+
+            .preview-episode {
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                padding: 4px 0;
+            }
+
+            .preview-episode-label {
+                flex: 1;
+                min-width: 0;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                font-size: 0.9em;
+            }
+
+            .preview-excluded .preview-title,
+            .preview-excluded .preview-episode-label {
+                opacity: 0.45;
+                text-decoration: line-through;
             }
         </style>
         <script type="text/javascript">
@@ -1494,6 +1610,164 @@
                 });
             }
 
+            // ===================== PREVIEW TAB =====================
+
+            var previewData = null;
+            var previewExpanded = {};
+
+            function escapeHtml(value) {
+                return String(value === null || value === undefined ? '' : value)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#39;');
+            }
+
+            function previewGroupKey(group) {
+                return group.Title + ' ' + group.EventType;
+            }
+
+            function loadPreview() {
+                var list = document.getElementById('PreviewList');
+                if (!list) return;
+
+                list.innerHTML = '<p class="no-configs-text">Loading&hellip;</p>';
+
+                ApiClient.getJSON(ApiClient.getUrl('Newsletters/Preview')).then(function (data) {
+                    previewData = data;
+                    renderPreview();
+                }).catch(function (error) {
+                    console.error('Error loading newsletter preview:', error);
+                    list.innerHTML = '<p class="no-configs-text">Could not load the preview. Check the Jellyfin logs.</p>';
+                });
+            }
+
+            function renderPreview() {
+                var list = document.getElementById('PreviewList');
+                var summary = document.getElementById('PreviewSummary');
+                if (!list || !previewData) return;
+
+                var groups = previewData.Groups || [];
+                var included = (previewData.TotalItems || 0) - (previewData.ExcludedItems || 0);
+
+                if (summary) {
+                    var sent = previewData.LastPublishedDate
+                        ? new Date(previewData.LastPublishedDate).toLocaleString()
+                        : 'never';
+                    summary.innerHTML = '<b>' + included + '</b> item(s) will be sent'
+                        + (previewData.ExcludedItems ? ', <b>' + previewData.ExcludedItems + '</b> excluded' : '')
+                        + '. Last newsletter sent: ' + escapeHtml(sent) + '.';
+                }
+
+                if (!groups.length) {
+                    list.innerHTML = '<p class="no-configs-text">Nothing queued for the next newsletter.</p>';
+                    return;
+                }
+
+                var html = '';
+                groups.forEach(function (group) {
+                    var key = previewGroupKey(group);
+                    var allExcluded = group.ExcludedCount === group.TotalCount;
+                    var eventType = (group.EventType || 'add').toLowerCase();
+                    var classes = 'preview-group' + (previewExpanded[key] ? ' expanded' : '')
+                        + (allExcluded ? ' preview-excluded' : '');
+
+                    var meta = [];
+                    if (group.SeasonSummary) meta.push(group.SeasonSummary);
+                    if (group.PremiereYear) meta.push(group.PremiereYear);
+                    if (group.LibraryName) meta.push(group.LibraryName);
+                    if (group.ExcludedCount && !allExcluded) {
+                        meta.push(group.ExcludedCount + ' of ' + group.TotalCount + ' excluded');
+                    }
+
+                    html += '<div class="' + classes + '" data-preview-key="' + escapeHtml(key) + '">';
+                    html += '  <div class="preview-group-header" onclick="togglePreviewGroup(this)">';
+                    html += '    <span class="expand-icon">' + (group.TotalCount > 1 ? '&#9656;' : '&nbsp;') + '</span>';
+                    html += '    <span class="preview-badge ' + escapeHtml(eventType) + '">' + escapeHtml(eventType) + '</span>';
+                    html += '    <span class="preview-title">' + escapeHtml(group.Title) + '</span>';
+                    html += '    <span class="preview-meta">' + escapeHtml(meta.join(' · ')) + '</span>';
+
+                    if (allExcluded) {
+                        html += '    <button type="button" class="config-action-btn test-btn" onclick="event.stopPropagation(); setPreviewGroupExcluded(this, false)">Restore</button>';
+                    } else {
+                        html += '    <button type="button" class="config-action-btn delete-btn" onclick="event.stopPropagation(); setPreviewGroupExcluded(this, true)">Remove</button>';
+                    }
+
+                    html += '  </div>';
+
+                    if (group.TotalCount > 1) {
+                        html += '  <div class="preview-episodes">';
+                        group.Items.forEach(function (item) {
+                            var label = item.Season >= 0 && item.Episode >= 0
+                                ? 'S' + ('0' + item.Season).slice(-2) + 'E' + ('0' + item.Episode).slice(-2)
+                                : item.Filename.split('/').pop();
+
+                            html += '<div class="preview-episode' + (item.Excluded ? ' preview-excluded' : '') + '"'
+                                + ' data-preview-file="' + escapeHtml(item.Filename) + '">';
+                            html += '  <span class="preview-episode-label" title="' + escapeHtml(item.Filename) + '">'
+                                + escapeHtml(label) + '</span>';
+                            html += item.Excluded
+                                ? '  <button type="button" class="config-action-btn test-btn" onclick="setPreviewItemExcluded(this, false)">Restore</button>'
+                                : '  <button type="button" class="config-action-btn delete-btn" onclick="setPreviewItemExcluded(this, true)">Remove</button>';
+                            html += '</div>';
+                        });
+                        html += '  </div>';
+                    }
+
+                    html += '</div>';
+                });
+
+                list.innerHTML = html;
+            }
+
+            function togglePreviewGroup(headerEl) {
+                var groupEl = headerEl.closest('.preview-group');
+                if (!groupEl || !groupEl.querySelector('.preview-episodes')) return;
+
+                var key = groupEl.getAttribute('data-preview-key');
+                previewExpanded[key] = !previewExpanded[key];
+                groupEl.classList.toggle('expanded');
+            }
+
+            function postPreviewChange(filenames, excluded) {
+                if (!filenames.length) return;
+
+                var url = ApiClient.getUrl('Newsletters/Preview/' + (excluded ? 'Exclude' : 'Include'));
+                ApiClient.ajax({
+                    type: 'POST',
+                    url: url,
+                    contentType: 'application/json',
+                    data: JSON.stringify({ Filenames: filenames })
+                }).then(function () {
+                    loadPreview();
+                }).catch(function (error) {
+                    console.error('Error updating newsletter preview:', error);
+                    alert('Could not update the newsletter preview. Check the Jellyfin logs.');
+                    loadPreview();
+                });
+            }
+
+            function setPreviewGroupExcluded(buttonEl, excluded) {
+                var groupEl = buttonEl.closest('.preview-group');
+                if (!groupEl || !previewData) return;
+
+                var key = groupEl.getAttribute('data-preview-key');
+                var group = (previewData.Groups || []).filter(function (g) {
+                    return previewGroupKey(g) === key;
+                })[0];
+                if (!group) return;
+
+                postPreviewChange(group.Items.map(function (i) { return i.Filename; }), excluded);
+            }
+
+            function setPreviewItemExcluded(buttonEl, excluded) {
+                var episodeEl = buttonEl.closest('.preview-episode');
+                if (!episodeEl) return;
+
+                postPreviewChange([episodeEl.getAttribute('data-preview-file')], excluded);
+            }
+
             function loadConfig() {
                 ApiClient.getPluginConfiguration(NewsletterConfig.pluginUniqueId).then(function (config) {
                     console.log("Loading config...", config);
@@ -1549,6 +1823,7 @@
                         renderEmailConfigs();
                         renderRadarrConfigs();
                         renderSonarrConfigs();
+                        loadPreview();
                         Dashboard.hideLoadingMsg();
                     });
                 });

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -1699,7 +1699,8 @@
                     if (group.TotalCount > 1) {
                         html += '  <div class="preview-episodes">';
                         group.Items.forEach(function (item) {
-                            var label = item.Season >= 0 && item.Episode >= 0
+                            var isEpisode = group.Type !== 'Movie' && item.Season >= 0 && item.Episode >= 0;
+                            var label = isEpisode
                                 ? 'S' + ('0' + item.Season).slice(-2) + 'E' + ('0' + item.Episode).slice(-2)
                                 : item.Filename.split('/').pop();
 

--- a/Jellyfin.Plugin.Newsletters/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Newsletters/PluginServiceRegistrator.cs
@@ -5,6 +5,7 @@ using Jellyfin.Plugin.Newsletters.Clients.Matrix;
 using Jellyfin.Plugin.Newsletters.Clients.Telegram;
 using Jellyfin.Plugin.Newsletters.Integrations;
 using Jellyfin.Plugin.Newsletters.ItemEventNotifier;
+using Jellyfin.Plugin.Newsletters.Preview;
 using Jellyfin.Plugin.Newsletters.Scanner;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
 using MediaBrowser.Controller;
@@ -38,6 +39,9 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
 
         // Register the integration services
         serviceCollection.AddSingleton<UpcomingMediaService>();
+
+        // Register the newsletter preview service
+        serviceCollection.AddSingleton<NewsletterPreviewService>();
 
         // Register the entry point for item event notifications
         serviceCollection.AddHostedService<ItemEventNotifierEntryPoint>();

--- a/Jellyfin.Plugin.Newsletters/Preview/NewsletterPreviewController.cs
+++ b/Jellyfin.Plugin.Newsletters/Preview/NewsletterPreviewController.cs
@@ -1,0 +1,80 @@
+using System.Net.Mime;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.Newsletters.Preview;
+
+/// <summary>
+/// API controller for previewing and editing the contents of the next newsletter.
+/// </summary>
+[ApiController]
+[Authorize(Policy = "RequiresElevation")]
+[Route("Newsletters/Preview")]
+[Produces(MediaTypeNames.Application.Json)]
+public class NewsletterPreviewController : ControllerBase
+{
+    private readonly NewsletterPreviewService previewService;
+    private readonly Logger logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NewsletterPreviewController"/> class.
+    /// </summary>
+    /// <param name="previewServiceInstance">The preview service instance.</param>
+    /// <param name="loggerInstance">The logger instance.</param>
+    public NewsletterPreviewController(NewsletterPreviewService previewServiceInstance, Logger loggerInstance)
+    {
+        previewService = previewServiceInstance;
+        logger = loggerInstance;
+    }
+
+    /// <summary>
+    /// Gets everything queued for the next newsletter.
+    /// </summary>
+    /// <returns>The grouped preview.</returns>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult<PreviewResponse> GetPreview()
+    {
+        logger.Debug("Building newsletter preview");
+        return Ok(previewService.GetPending());
+    }
+
+    /// <summary>
+    /// Excludes the given queued files from the next newsletter.
+    /// </summary>
+    /// <param name="selection">The filenames to exclude.</param>
+    /// <returns>An <see cref="IActionResult"/> indicating success.</returns>
+    [HttpPost("Exclude")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public IActionResult Exclude([FromBody] PreviewSelection selection)
+    {
+        if (selection?.Filenames is null || selection.Filenames.Count == 0)
+        {
+            return BadRequest(new { Message = "No items specified." });
+        }
+
+        int count = previewService.SetExcluded(selection.Filenames, true);
+        return Ok(new { Message = $"Excluded {count} item(s) from the next newsletter.", Count = count });
+    }
+
+    /// <summary>
+    /// Puts previously excluded files back into the next newsletter.
+    /// </summary>
+    /// <param name="selection">The filenames to re-include.</param>
+    /// <returns>An <see cref="IActionResult"/> indicating success.</returns>
+    [HttpPost("Include")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public IActionResult Include([FromBody] PreviewSelection selection)
+    {
+        if (selection?.Filenames is null || selection.Filenames.Count == 0)
+        {
+            return BadRequest(new { Message = "No items specified." });
+        }
+
+        int count = previewService.SetExcluded(selection.Filenames, false);
+        return Ok(new { Message = $"Restored {count} item(s) to the next newsletter.", Count = count });
+    }
+}

--- a/Jellyfin.Plugin.Newsletters/Preview/NewsletterPreviewController.cs
+++ b/Jellyfin.Plugin.Newsletters/Preview/NewsletterPreviewController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Mime;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -48,6 +49,7 @@ public class NewsletterPreviewController : ControllerBase
     [HttpPost("Exclude")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public IActionResult Exclude([FromBody] PreviewSelection selection)
     {
         if (selection?.Filenames is null || selection.Filenames.Count == 0)
@@ -55,8 +57,16 @@ public class NewsletterPreviewController : ControllerBase
             return BadRequest(new { Message = "No items specified." });
         }
 
-        int count = previewService.SetExcluded(selection.Filenames, true);
-        return Ok(new { Message = $"Excluded {count} item(s) from the next newsletter.", Count = count });
+        try
+        {
+            int count = previewService.SetExcluded(selection.Filenames, true);
+            return Ok(new { Message = $"Excluded {count} item(s) from the next newsletter.", Count = count });
+        }
+        catch (Exception e)
+        {
+            logger.Error("Could not exclude items from the next newsletter: " + e);
+            return StatusCode(StatusCodes.Status500InternalServerError, new { Message = "Could not update the newsletter queue." });
+        }
     }
 
     /// <summary>
@@ -67,6 +77,7 @@ public class NewsletterPreviewController : ControllerBase
     [HttpPost("Include")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public IActionResult Include([FromBody] PreviewSelection selection)
     {
         if (selection?.Filenames is null || selection.Filenames.Count == 0)
@@ -74,7 +85,15 @@ public class NewsletterPreviewController : ControllerBase
             return BadRequest(new { Message = "No items specified." });
         }
 
-        int count = previewService.SetExcluded(selection.Filenames, false);
-        return Ok(new { Message = $"Restored {count} item(s) to the next newsletter.", Count = count });
+        try
+        {
+            int count = previewService.SetExcluded(selection.Filenames, false);
+            return Ok(new { Message = $"Restored {count} item(s) to the next newsletter.", Count = count });
+        }
+        catch (Exception e)
+        {
+            logger.Error("Could not restore items to the next newsletter: " + e);
+            return StatusCode(StatusCodes.Status500InternalServerError, new { Message = "Could not update the newsletter queue." });
+        }
     }
 }

--- a/Jellyfin.Plugin.Newsletters/Preview/NewsletterPreviewService.cs
+++ b/Jellyfin.Plugin.Newsletters/Preview/NewsletterPreviewService.cs
@@ -133,7 +133,10 @@ public class NewsletterPreviewService(
     /// </summary>
     /// <param name="filenames">The filenames to act on.</param>
     /// <param name="excluded">True to exclude, false to re-include.</param>
-    /// <returns>The number of filenames acted on.</returns>
+    /// <returns>The number of queued rows actually updated, which is less than the number of
+    /// filenames supplied when some of them are no longer queued.</returns>
+    /// <exception cref="Exception">Thrown when the queue could not be updated, so that the caller
+    /// reports the failure instead of silently reporting success.</exception>
     public int SetExcluded(IReadOnlyList<string> filenames, bool excluded)
     {
         if (filenames is null || filenames.Count == 0)
@@ -148,13 +151,22 @@ public class NewsletterPreviewService(
             string list = string.Join(",", filenames.Select(Sanitize));
             db.ExecuteSQL($"UPDATE CurrNewsletterData SET Excluded={(excluded ? 1 : 0)} WHERE Filename IN ({list});");
 
-            logger.Info($"{(excluded ? "Excluded" : "Re-included")} {filenames.Count} item(s) for the next newsletter");
-            return filenames.Count;
+            int changed = 0;
+            foreach (var row in db.Query("SELECT changes();"))
+            {
+                if (row is not null)
+                {
+                    changed = ParseInt(row[0].ToString());
+                }
+            }
+
+            logger.Info($"{(excluded ? "Excluded" : "Re-included")} {changed} of {filenames.Count} requested item(s) for the next newsletter");
+            return changed;
         }
         catch (Exception e)
         {
             logger.Error("An error has occured: " + e);
-            return 0;
+            throw;
         }
         finally
         {

--- a/Jellyfin.Plugin.Newsletters/Preview/NewsletterPreviewService.cs
+++ b/Jellyfin.Plugin.Newsletters/Preview/NewsletterPreviewService.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Jellyfin.Plugin.Newsletters.Shared;
+using Jellyfin.Plugin.Newsletters.Shared.Database;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.Newsletters.Preview;
+
+/// <summary>
+/// Reads and edits the queue of items awaiting the next newsletter.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="NewsletterPreviewService"/> class.
+/// </remarks>
+/// <param name="loggerInstance">The logger instance.</param>
+/// <param name="dbInstance">The database instance.</param>
+/// <param name="libraryManagerInstance">The library manager instance.</param>
+public class NewsletterPreviewService(
+    Logger loggerInstance,
+    SQLiteDatabase dbInstance,
+    ILibraryManager libraryManagerInstance)
+{
+    private static readonly Dictionary<string, int> EventTypeOrder = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { "add", 0 }, { "update", 1 }, { "delete", 2 }
+    };
+
+    private readonly Logger logger = loggerInstance;
+    private readonly SQLiteDatabase db = dbInstance;
+    private readonly ILibraryManager libraryManager = libraryManagerInstance;
+
+    /// <summary>
+    /// Gets everything currently queued for the next newsletter, grouped by title and event type.
+    /// Excluded items are included in the result, flagged, so the UI can show and undo them.
+    /// </summary>
+    /// <returns>The grouped preview of the next newsletter.</returns>
+    public PreviewResponse GetPending()
+    {
+        var libraryNameMap = LibraryNames.BuildMap(libraryManager, logger);
+        var groups = new Dictionary<string, PreviewGroup>(StringComparer.Ordinal);
+        var items = new Dictionary<string, List<PreviewItem>>(StringComparer.Ordinal);
+
+        try
+        {
+            db.CreateConnection();
+
+            const string Sql = "SELECT Filename, Title, Season, Episode, ImageURL, Type, " +
+                               "PremiereYear, EventType, LibraryId, Excluded FROM CurrNewsletterData;";
+
+            foreach (var row in db.Query(Sql))
+            {
+                if (row is null)
+                {
+                    continue;
+                }
+
+                string title = row[1].ToString();
+                string eventType = string.IsNullOrEmpty(row[7].ToString()) ? "Add" : row[7].ToString();
+                string key = title + " " + eventType;
+
+                if (!groups.TryGetValue(key, out var group))
+                {
+                    group = new PreviewGroup
+                    {
+                        Title = title,
+                        EventType = eventType,
+                        Type = row[5].ToString(),
+                        LibraryName = LibraryNames.Resolve(row[8].ToString(), libraryNameMap),
+                        PremiereYear = row[6].ToString(),
+                        ImageURL = row[4].ToString()
+                    };
+
+                    groups[key] = group;
+                    items[key] = new List<PreviewItem>();
+                }
+
+                if (string.IsNullOrEmpty(group.ImageURL))
+                {
+                    group.ImageURL = row[4].ToString();
+                }
+
+                items[key].Add(new PreviewItem
+                {
+                    Filename = row[0].ToString(),
+                    Season = ParseInt(row[2].ToString()),
+                    Episode = ParseInt(row[3].ToString()),
+                    Excluded = ParseInt(row[9].ToString()) == 1
+                });
+            }
+        }
+        catch (Exception e)
+        {
+            logger.Error("An error has occured: " + e);
+        }
+        finally
+        {
+            db.CloseConnection();
+        }
+
+        foreach (var (key, group) in groups)
+        {
+            var groupItems = items[key]
+                .OrderBy(i => i.Season)
+                .ThenBy(i => i.Episode)
+                .ToList();
+
+            group.Items = groupItems;
+            group.TotalCount = groupItems.Count;
+            group.ExcludedCount = groupItems.Count(i => i.Excluded);
+            group.SeasonSummary = Preview.SeasonSummary.Format(groupItems.Select(i => (i.Season, i.Episode)).ToList());
+        }
+
+        var ordered = groups.Values
+            .OrderBy(g => EventTypeOrder.GetValueOrDefault(g.EventType ?? "add", 0))
+            .ThenBy(g => g.Type == "Movie" ? 0 : 1)
+            .ThenBy(g => g.LibraryName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(g => g.Title, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new PreviewResponse
+        {
+            Groups = ordered,
+            TotalItems = ordered.Sum(g => g.TotalCount),
+            ExcludedItems = ordered.Sum(g => g.ExcludedCount),
+            LastPublishedDate = Plugin.Instance!.Configuration.LastPublishedDate
+        };
+    }
+
+    /// <summary>
+    /// Excludes the given queued files from the next newsletter, or puts them back.
+    /// </summary>
+    /// <param name="filenames">The filenames to act on.</param>
+    /// <param name="excluded">True to exclude, false to re-include.</param>
+    /// <returns>The number of filenames acted on.</returns>
+    public int SetExcluded(IReadOnlyList<string> filenames, bool excluded)
+    {
+        if (filenames is null || filenames.Count == 0)
+        {
+            return 0;
+        }
+
+        try
+        {
+            db.CreateConnection();
+
+            string list = string.Join(",", filenames.Select(Sanitize));
+            db.ExecuteSQL($"UPDATE CurrNewsletterData SET Excluded={(excluded ? 1 : 0)} WHERE Filename IN ({list});");
+
+            logger.Info($"{(excluded ? "Excluded" : "Re-included")} {filenames.Count} item(s) for the next newsletter");
+            return filenames.Count;
+        }
+        catch (Exception e)
+        {
+            logger.Error("An error has occured: " + e);
+            return 0;
+        }
+        finally
+        {
+            db.CloseConnection();
+        }
+    }
+
+    private static string Sanitize(string value)
+    {
+        return "'" + (value ?? string.Empty).Replace("'", "''", StringComparison.Ordinal) + "'";
+    }
+
+    private static int ParseInt(string value)
+    {
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed) ? parsed : -1;
+    }
+}

--- a/Jellyfin.Plugin.Newsletters/Preview/NewsletterPreviewService.cs
+++ b/Jellyfin.Plugin.Newsletters/Preview/NewsletterPreviewService.cs
@@ -109,7 +109,7 @@ public class NewsletterPreviewService(
             group.Items = groupItems;
             group.TotalCount = groupItems.Count;
             group.ExcludedCount = groupItems.Count(i => i.Excluded);
-            group.SeasonSummary = Preview.SeasonSummary.Format(groupItems.Select(i => (i.Season, i.Episode)).ToList());
+            group.SeasonSummary = BuildSeasonSummary(group.Type, groupItems);
         }
 
         var ordered = groups.Values
@@ -160,6 +160,29 @@ public class NewsletterPreviewService(
         {
             db.CloseConnection();
         }
+    }
+
+    /// <summary>
+    /// Summarises the seasons and episodes a group will actually send.
+    /// </summary>
+    /// <remarks>
+    /// Movies carry no season or episode, but the scanner stores 0 rather than a sentinel
+    /// (<see cref="Shared.Entities.JsonFileObj"/> initialises both to 0), so the media type is the
+    /// only reliable discriminator - season 0 is legitimately "Specials" for a series.
+    /// Excluded items are left out so the summary describes what will be sent, falling back to the
+    /// full set when everything is excluded so a struck-through card still says what it covers.
+    /// </remarks>
+    private static string BuildSeasonSummary(string type, List<PreviewItem> groupItems)
+    {
+        if (string.Equals(type, "Movie", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Empty;
+        }
+
+        var included = groupItems.Where(i => !i.Excluded).ToList();
+        var describing = included.Count > 0 ? included : groupItems;
+
+        return SeasonSummary.Format(describing.Select(i => (i.Season, i.Episode)).ToList());
     }
 
     private static string Sanitize(string value)

--- a/Jellyfin.Plugin.Newsletters/Preview/PreviewGroup.cs
+++ b/Jellyfin.Plugin.Newsletters/Preview/PreviewGroup.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.Newsletters.Preview;
+
+/// <summary>
+/// Queued files grouped the way the newsletter renders them: one group per title and event type.
+/// </summary>
+public class PreviewGroup
+{
+    /// <summary>
+    /// Gets or sets the title of the series or movie.
+    /// </summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the event type (Add, Update or Delete).
+    /// </summary>
+    public string EventType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the media type (Series or Movie).
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the display name of the library the item belongs to.
+    /// </summary>
+    public string LibraryName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the premiere year.
+    /// </summary>
+    public string PremiereYear { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the poster URL.
+    /// </summary>
+    public string ImageURL { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the short season and episode summary, for example "S1 E1-3".
+    /// </summary>
+    public string SeasonSummary { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the number of queued files in this group.
+    /// </summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many of those files are excluded.
+    /// </summary>
+    public int ExcludedCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the individual queued files.
+    /// </summary>
+    public IReadOnlyList<PreviewItem> Items { get; set; } = Array.Empty<PreviewItem>();
+}

--- a/Jellyfin.Plugin.Newsletters/Preview/PreviewItem.cs
+++ b/Jellyfin.Plugin.Newsletters/Preview/PreviewItem.cs
@@ -1,0 +1,27 @@
+namespace Jellyfin.Plugin.Newsletters.Preview;
+
+/// <summary>
+/// A single queued file (one episode, or one movie) awaiting the next newsletter.
+/// </summary>
+public class PreviewItem
+{
+    /// <summary>
+    /// Gets or sets the filename, which is the primary key of the queue table.
+    /// </summary>
+    public string Filename { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the season number, or -1 for movies.
+    /// </summary>
+    public int Season { get; set; }
+
+    /// <summary>
+    /// Gets or sets the episode number, or -1 for movies.
+    /// </summary>
+    public int Episode { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this item is excluded from the next newsletter.
+    /// </summary>
+    public bool Excluded { get; set; }
+}

--- a/Jellyfin.Plugin.Newsletters/Preview/PreviewResponse.cs
+++ b/Jellyfin.Plugin.Newsletters/Preview/PreviewResponse.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.Newsletters.Preview;
+
+/// <summary>
+/// The full preview of the next newsletter.
+/// </summary>
+public class PreviewResponse
+{
+    /// <summary>
+    /// Gets or sets the queued groups, in the order the newsletter renders them.
+    /// </summary>
+    public IReadOnlyList<PreviewGroup> Groups { get; set; } = Array.Empty<PreviewGroup>();
+
+    /// <summary>
+    /// Gets or sets the total number of queued files.
+    /// </summary>
+    public int TotalItems { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many queued files are excluded.
+    /// </summary>
+    public int ExcludedItems { get; set; }
+
+    /// <summary>
+    /// Gets or sets when the last newsletter was sent, if ever.
+    /// </summary>
+    public DateTime? LastPublishedDate { get; set; }
+}

--- a/Jellyfin.Plugin.Newsletters/Preview/PreviewSelection.cs
+++ b/Jellyfin.Plugin.Newsletters/Preview/PreviewSelection.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.Newsletters.Preview;
+
+/// <summary>
+/// A set of queued files to exclude or re-include, identified by filename.
+/// </summary>
+public class PreviewSelection
+{
+    /// <summary>
+    /// Gets or sets the filenames to act on.
+    /// </summary>
+    public IReadOnlyList<string> Filenames { get; set; } = Array.Empty<string>();
+}

--- a/Jellyfin.Plugin.Newsletters/Preview/SeasonSummary.cs
+++ b/Jellyfin.Plugin.Newsletters/Preview/SeasonSummary.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Jellyfin.Plugin.Newsletters.Preview;
+
+/// <summary>
+/// Formats the season and episode numbers of a queued group into a short human-readable summary.
+/// </summary>
+public static class SeasonSummary
+{
+    /// <summary>
+    /// Builds a summary such as "S1 E1-3, S2 E5". Movies, which the scanner stores with
+    /// season and episode -1, produce an empty string.
+    /// </summary>
+    /// <param name="episodes">The season/episode pairs belonging to one queued group.</param>
+    /// <returns>The formatted summary, or an empty string when there is nothing to describe.</returns>
+    public static string Format(IReadOnlyList<(int Season, int Episode)> episodes)
+    {
+        if (episodes is null || episodes.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var parts = new List<string>();
+
+        foreach (var season in episodes.Where(e => e.Season >= 0).GroupBy(e => e.Season).OrderBy(g => g.Key))
+        {
+            var numbers = season.Select(e => e.Episode)
+                                .Where(e => e >= 0)
+                                .Distinct()
+                                .OrderBy(e => e)
+                                .ToList();
+
+            string label = "S" + season.Key.ToString(CultureInfo.InvariantCulture);
+            parts.Add(numbers.Count == 0 ? label : label + " E" + FormatRuns(numbers));
+        }
+
+        return string.Join(", ", parts);
+    }
+
+    private static string FormatRuns(List<int> sorted)
+    {
+        var runs = new List<string>();
+        int start = sorted[0];
+        int previous = start;
+
+        for (int i = 1; i <= sorted.Count; i++)
+        {
+            if (i < sorted.Count && sorted[i] == previous + 1)
+            {
+                previous = sorted[i];
+                continue;
+            }
+
+            runs.Add(start == previous
+                ? start.ToString(CultureInfo.InvariantCulture)
+                : start.ToString(CultureInfo.InvariantCulture) + "-" + previous.ToString(CultureInfo.InvariantCulture));
+
+            if (i < sorted.Count)
+            {
+                start = previous = sorted[i];
+            }
+        }
+
+        return string.Join(", ", runs);
+    }
+}

--- a/Jellyfin.Plugin.Newsletters/Scanner/Scraper.cs
+++ b/Jellyfin.Plugin.Newsletters/Scanner/Scraper.cs
@@ -687,6 +687,13 @@ public class Scraper
 
     private void CopyCurrRunDataToNewsletterData()
     {
+        // The copy below replaces queued rows by Filename, and scanned rows carry no Excluded value,
+        // so carry any admin exclusion across first. Without this, re-queuing a file (a Sonarr/Radarr
+        // upgrade fires Delete then Add, which lands as an Update for the same path) silently puts an
+        // item the admin removed in the Preview tab back into the next newsletter.
+        db.ExecuteSQL("UPDATE CurrRunData SET Excluded = (SELECT n.Excluded FROM CurrNewsletterData n WHERE n.Filename = CurrRunData.Filename) " +
+                      "WHERE EXISTS (SELECT 1 FROM CurrNewsletterData n WHERE n.Filename = CurrRunData.Filename);");
+
         // -> copy CurrData Table to NewsletterDataTable
         // -> clear CurrData table
         db.ExecuteSQL("INSERT OR REPLACE INTO CurrNewsletterData SELECT * FROM CurrRunData;");

--- a/Jellyfin.Plugin.Newsletters/Shared/Database/SQLiteDatabase.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/Database/SQLiteDatabase.cs
@@ -11,6 +11,12 @@ namespace Jellyfin.Plugin.Newsletters.Shared.Database;
 /// </summary>
 public class SQLiteDatabase
 {
+    /// <summary>
+    /// SQL predicate matching only rows that have not been excluded from the next newsletter.
+    /// Older databases predate the column, so NULL counts as "not excluded".
+    /// </summary>
+    public const string NotExcludedClause = "(Excluded IS NULL OR Excluded = 0)";
+
     private readonly PluginConfiguration config;
     private readonly string dbFilePath;
     private readonly string dbLockPath;
@@ -115,6 +121,7 @@ public class SQLiteDatabase
             new_cols.Add("EventType", "TEXT");
             new_cols.Add("LibraryId", "TEXT");
             new_cols.Add("Genres", "TEXT");
+            new_cols.Add("Excluded", "INT");
 
             var existingColumns = GetTableColumns(table);
 
@@ -133,6 +140,12 @@ public class SQLiteDatabase
                             // For backward compatibility, set existing records to "Add" since previous version only had additions
                             logger.Debug($"Setting default EventType='Add' for existing records in {table}");
                             ExecuteSQL($"UPDATE {table} SET EventType='Add' WHERE EventType IS NULL;");
+                        }
+
+                        if (col.Key == "Excluded")
+                        {
+                            logger.Debug($"Setting default Excluded=0 for existing records in {table}");
+                            ExecuteSQL($"UPDATE {table} SET Excluded=0 WHERE Excluded IS NULL;");
                         }
                     }
                     catch (SQLiteException sle)

--- a/Jellyfin.Plugin.Newsletters/Shared/LibraryNames.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/LibraryNames.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.Newsletters.Shared;
+
+/// <summary>
+/// Resolves Jellyfin library (virtual folder) IDs to their display names.
+/// </summary>
+public static class LibraryNames
+{
+    /// <summary>
+    /// Builds a dictionary mapping library ID to library name.
+    /// </summary>
+    /// <param name="libraryManager">The Jellyfin library manager.</param>
+    /// <param name="logger">The logger used to report lookup failures.</param>
+    /// <returns>A dictionary mapping library IDs to names. Empty if the lookup fails.</returns>
+    public static Dictionary<string, string> BuildMap(ILibraryManager libraryManager, Logger logger)
+    {
+        var map = new Dictionary<string, string>();
+
+        try
+        {
+            foreach (var folder in libraryManager.GetVirtualFolders())
+            {
+                if (!string.IsNullOrEmpty(folder.ItemId) && !map.ContainsKey(folder.ItemId))
+                {
+                    map[folder.ItemId] = folder.Name;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"Error building library name map: {ex.Message}");
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Gets the library name for a library ID, falling back to "Library" when unknown.
+    /// </summary>
+    /// <param name="libraryId">The library ID to look up.</param>
+    /// <param name="map">The map produced by <see cref="BuildMap"/>.</param>
+    /// <returns>The library name, or "Library" if the ID is not present.</returns>
+    public static string Resolve(string? libraryId, Dictionary<string, string> map)
+    {
+        if (!string.IsNullOrEmpty(libraryId) && map.TryGetValue(libraryId, out var name))
+        {
+            return name;
+        }
+
+        return "Library";
+    }
+}


### PR DESCRIPTION
## What this adds

A **Preview** tab in the plugin settings that shows everything queued for the next newsletter, and lets an admin drop individual entries before it sends.

The queue (`CurrNewsletterData`) was previously invisible — you found out what the newsletter contained when it landed in your inbox. This makes it inspectable and correctable: a botched import, a mis-tagged episode, or a duplicate can be removed instead of going out to everyone.

## How it works

- **New `Excluded` column** on the newsletter tables, added through the existing generic `new_cols` migration loop in `SQLiteDatabase.CreateTables`, so all three tables get it in the same order and the `INSERT INTO ArchiveData SELECT * FROM CurrNewsletterData` copy stays column-compatible. Existing rows are backfilled to `0` the same way `EventType` is. `JsonFileObj.ConvertToObj` reads indices 0-15, so the appended column is safe.
- **Exclusion is soft and reversible.** Excluded entries stay listed, greyed and struck through, with a Restore button, until the newsletter sends. They are archived along with everything else on send, so the queue still self-cleans and nothing accumulates.
- **Three read paths filter on it** via a shared `SQLiteDatabase.NotExcludedClause` predicate (`Excluded IS NULL OR Excluded = 0`, so older databases that predate the column behave correctly):
  - `ClientBuilder.BuildSortedItems`
  - `ClientBuilder.ParseSeriesInfo`
  - `Client.NewsletterDbIsPopulated` — this one matters: without it a queue holding only excluded rows still reports "has data" and an empty newsletter goes out.

  `CopyNewsletterDataToArchive` and `Scraper.SetImageURL` are deliberately left unfiltered — the first so excluded rows still archive, the second because an excluded row's cached poster URL is still a valid cache hit.
- **`Preview/NewsletterPreviewService`** groups pending rows by `Title + EventType`, the same key `BuildSortedItems` renders by, and orders them the same way (event type, then movies before series, then library). `Preview/NewsletterPreviewController` exposes it:

  | Verb | Route |
  |------|-------|
  | GET | `/Newsletters/Preview` |
  | POST | `/Newsletters/Preview/Exclude` |
  | POST | `/Newsletters/Preview/Include` |

  Both POSTs take `{ "Filenames": [...] }` — `Filename` is the table's primary key. Admin-only (`RequiresElevation`), matching `UpcomingMediaController`.
- **The config page tab** renders one card per group with a caret to expand into individual episodes, and Remove/Restore at both levels. Actions hit the API immediately and are database state rather than plugin config, so Save is not involved — the tab says so.

## Notes on scope

- **Upcoming (Radarr/Sonarr) items are not listed.** They are fetched live when the newsletter is built and never stored, so they cannot be excluded persistently; listing them would also put a network call to Radarr/Sonarr on every tab open. The tab says where they come from instead.
- **The list is not filtered per client.** Each client config has its own library selection and event toggles, so contents differ per client; the tab shows the whole queue with the library name on each card, and exclusion applies to every client.
- **`ParseSeriesInfo`'s episode-range logic is untouched.** The preview computes its own summary with a small dedicated formatter (`Preview/SeasonSummary`) rather than refactoring ~130 lines of the core render path, which there is no test harness to verify against.
- `BuildLibraryNameMap` / `GetLibraryName` moved out of `ClientBuilder` into `Shared/LibraryNames` so the preview service can share them; the `ClientBuilder` methods remain as thin wrappers, so nothing else in that class changes.

One detail worth knowing for future work: movies are stored with `Season`/`Episode` of **0**, not a sentinel — `JsonFileObj`'s constructor initialises both to 0, and the `is null` guard in `AddItemToDatabase` can never fire on an `int`. So the media type is the only reliable way to tell a movie from a series, since season 0 is legitimately "Specials". The summary gates on `Type` for that reason.

## Testing

Built against net9.0 and deployed to a live Jellyfin 10.11.11 server with 38 queued items across 7 groups (adds, an update, and deletes; movies and series):

- Migration applied to an existing populated database on first connection; `Excluded` present, existing rows defaulted to 0.
- Grouping, ordering and episode-range collapsing match the newsletter (`S2 E1-14`, `S1 E1-10`).
- Excluding a whole 10-episode group moved the send count from 38 to 28; the group renders as fully excluded with Restore.
- Excluding 2 of 14 episodes reported `2/14` and narrowed the summary from `S2 E1-14` to `S2 E3-14`, so the card describes what will actually be sent.
- Include restored every row (`SUM(Excluded) = 0`).
- Plugin loads with no exceptions.

`SeasonSummary` was additionally verified against 9 cases: empty, movie, contiguous run, gap, single, multi-season, unsorted input, duplicates, and season-without-episode.

Per CONTRIBUTING.md, this was built locally against ImageSharp 3.1.12 rather than 4.0.0; the downgrade was kept in an untracked `Directory.Build.targets` so it is not part of this diff.
