### PR TITLE
Per-library emojis for newsletter section headers

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
@@ -24,6 +24,8 @@ public class ClientBuilder(Logger loggerInstance,
     SQLiteDatabase dbInstance,
     ILibraryManager libraryManagerInstance)
 {
+    private Dictionary<string, string>? libraryEmojiMap;
+
     /// <summary>
     /// Gets the plugin configuration instance.
     /// </summary>
@@ -43,6 +45,12 @@ public class ClientBuilder(Logger loggerInstance,
     /// Gets the library manager instance.
     /// </summary>
     protected ILibraryManager LibraryManager { get; } = libraryManagerInstance;
+
+    /// <summary>
+    /// Gets the map of library name to section-header emoji, built once per newsletter run.
+    /// </summary>
+    protected Dictionary<string, string> LibraryEmojiMap =>
+        libraryEmojiMap ??= LibraryEmojis.BuildMap(LibraryManager, Logger, Config.LibraryEmojis);
 
     /// <summary>
     /// Queries newsletter data from the database, merges upcoming items, deduplicates,

--- a/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
@@ -50,7 +50,7 @@ public abstract class HtmlContentBuilder(
 
     /// <summary>
     /// Gets the HTML section header for an event type and library name.
-    /// Loads the header from the parsed template and substitutes {LibraryName} and {LibraryEmoji}.
+    /// Loads the header from the parsed template and substitutes {LibraryName}, {LibraryEmoji} and {EventEmoji}.
     /// </summary>
     /// <param name="eventType">The event type (add, update, delete, upcoming).</param>
     /// <param name="libraryName">The library name to display.</param>
@@ -73,7 +73,8 @@ public abstract class HtmlContentBuilder(
         }
 
         string header = this.TemplateReplace(headerTemplate, "{LibraryName}", libraryName);
-        return this.TemplateReplace(header, "{LibraryEmoji}", LibraryEmojis.Resolve(libraryName, LibraryEmojiMap));
+        header = this.TemplateReplace(header, "{LibraryEmoji}", LibraryEmojis.Resolve(libraryName, LibraryEmojiMap));
+        return this.TemplateReplace(header, "{EventEmoji}", EventEmojis.Resolve(eventType, Config));
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
@@ -50,7 +50,7 @@ public abstract class HtmlContentBuilder(
 
     /// <summary>
     /// Gets the HTML section header for an event type and library name.
-    /// Loads the header from the parsed template and substitutes {LibraryName}.
+    /// Loads the header from the parsed template and substitutes {LibraryName} and {LibraryEmoji}.
     /// </summary>
     /// <param name="eventType">The event type (add, update, delete, upcoming).</param>
     /// <param name="libraryName">The library name to display.</param>
@@ -72,7 +72,8 @@ public abstract class HtmlContentBuilder(
             return string.Empty;
         }
 
-        return this.TemplateReplace(headerTemplate, "{LibraryName}", libraryName);
+        string header = this.TemplateReplace(headerTemplate, "{LibraryName}", libraryName);
+        return this.TemplateReplace(header, "{LibraryEmoji}", LibraryEmojis.Resolve(libraryName, LibraryEmojiMap));
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Newsletters/Configuration/LibraryEmojiConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/LibraryEmojiConfiguration.cs
@@ -1,0 +1,18 @@
+namespace Jellyfin.Plugin.Newsletters.Configuration;
+
+/// <summary>
+/// A per-library emoji override for newsletter section headers.
+/// </summary>
+public class LibraryEmojiConfiguration
+{
+    /// <summary>
+    /// Gets or sets the Jellyfin library (virtual folder) ID this override applies to.
+    /// </summary>
+    public string LibraryId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the emoji to show in that library's section headers.
+    /// An empty value falls back to the default for the library's collection type.
+    /// </summary>
+    public string Emoji { get; set; } = string.Empty;
+}

--- a/Jellyfin.Plugin.Newsletters/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/PluginConfiguration.cs
@@ -481,6 +481,12 @@ public class PluginConfiguration : BasePluginConfiguration
     public Collection<RadarrConfiguration> RadarrConfigurations { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets the per-library emoji overrides used in newsletter section headers.
+    /// Libraries without an entry use the default for their collection type.
+    /// </summary>
+    public Collection<LibraryEmojiConfiguration> LibraryEmojis { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the collection of Sonarr instance configurations.
     /// </summary>
     public Collection<SonarrConfiguration> SonarrConfigurations { get; set; } = new();

--- a/Jellyfin.Plugin.Newsletters/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/PluginConfiguration.cs
@@ -487,6 +487,26 @@ public class PluginConfiguration : BasePluginConfiguration
     public Collection<LibraryEmojiConfiguration> LibraryEmojis { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets the emoji shown beside "Added to ..." section headings. Empty uses the default.
+    /// </summary>
+    public string EventEmojiAdd { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the emoji shown beside "Updated in ..." section headings. Empty uses the default.
+    /// </summary>
+    public string EventEmojiUpdate { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the emoji shown beside "Removed from ..." section headings. Empty uses the default.
+    /// </summary>
+    public string EventEmojiDelete { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the emoji shown beside "Upcoming in ..." section headings. Empty uses the default.
+    /// </summary>
+    public string EventEmojiUpcoming { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets the collection of Sonarr instance configurations.
     /// </summary>
     public Collection<SonarrConfiguration> SonarrConfigurations { get; set; } = new();

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -88,6 +88,20 @@
                         </div>
 
                         <hr>
+                        <h3>Section Emojis</h3>
+                        <div class="fieldDescription" style="margin-bottom: 15px;">
+                            The emoji shown beside each section heading in the newsletter, per library.
+                            Leave a box empty to use the default for that library's type.
+                            <br>
+                            Applies wherever a header template uses <b>{LibraryEmoji}</b> &mdash; the bundled
+                            templates do. If you have pasted your own Header HTML into a client below, add the
+                            placeholder there to pick these up.
+                        </div>
+                        <div id="LibraryEmojiList" class="config-list">
+                            <p class="no-configs-text">Loading libraries&hellip;</p>
+                        </div>
+
+                        <hr>
                         <h3>Upcoming Media Integration</h3>
                         <div class="fieldDescription" style="margin-bottom: 15px;">
                             Connect to Radarr and/or Sonarr to include an "Upcoming" section in your newsletters
@@ -538,6 +552,37 @@
             .preview-excluded .preview-episode-label {
                 opacity: 0.45;
                 text-decoration: line-through;
+            }
+            /* Section Emojis */
+            .emoji-table {
+                width: 100%;
+                border-collapse: collapse;
+            }
+
+            .emoji-table td {
+                padding: 6px 10px;
+                vertical-align: middle;
+            }
+
+            .emoji-lib-name {
+                width: 45%;
+            }
+
+            .emoji-lib-input {
+                width: 30%;
+            }
+
+            .emoji-lib-input input {
+                width: 100%;
+                font-size: 1.2em;
+                text-align: center;
+            }
+
+            .emoji-lib-default {
+                width: 25%;
+                opacity: 0.6;
+                font-size: 0.85em;
+                white-space: nowrap;
             }
         </style>
         <script type="text/javascript">
@@ -1565,6 +1610,78 @@
 
             // ===================== LIBRARY FUNCTIONS =====================
 
+            // ===================== SECTION EMOJIS =====================
+
+            // Mirrors LibraryEmojis.DefaultsByCollectionType on the server so the
+            // placeholder shows the emoji that will actually be used.
+            var EMOJI_DEFAULTS = {
+                movies: '🍿',
+                tvshows: '🎬',
+                music: '🎵',
+                musicvideos: '🎤',
+                books: '📚',
+                homevideos: '📹',
+                boxsets: '📦',
+                mixed: '🎞️'
+            };
+            var EMOJI_FALLBACK = '🎞️';
+
+            function defaultEmojiFor(collectionType) {
+                var key = (collectionType || '').toLowerCase();
+                return EMOJI_DEFAULTS[key] || EMOJI_FALLBACK;
+            }
+
+            function renderLibraryEmojis(configured) {
+                var container = document.getElementById('LibraryEmojiList');
+                if (!container) return;
+
+                if (!allLibraries || !allLibraries.length) {
+                    container.innerHTML = '<p class="no-configs-text">No libraries found.</p>';
+                    return;
+                }
+
+                var byId = {};
+                (configured || []).forEach(function (entry) {
+                    if (entry && entry.LibraryId) byId[entry.LibraryId] = entry.Emoji || '';
+                });
+
+                var html = '<table class="emoji-table">';
+                allLibraries.forEach(function (lib) {
+                    var fallback = defaultEmojiFor(lib.CollectionType);
+                    html += '<tr>';
+                    html += '  <td class="emoji-lib-name">' + escapeHtml(lib.Name) + '</td>';
+                    html += '  <td class="emoji-lib-input"><input type="text" is="emby-input" maxlength="8"'
+                        + ' class="library-emoji" data-library-id="' + escapeHtml(lib.Id) + '"'
+                        + ' value="' + escapeHtml(byId[lib.Id] || '') + '"'
+                        + ' placeholder="' + escapeHtml(fallback) + '" /></td>';
+                    html += '  <td class="emoji-lib-default">default ' + escapeHtml(fallback) + '</td>';
+                    html += '</tr>';
+                });
+                html += '</table>';
+
+                container.innerHTML = html;
+            }
+
+            function collectLibraryEmojis() {
+                var result = [];
+                document.querySelectorAll('.library-emoji').forEach(function (input) {
+                    var value = (input.value || '').trim();
+                    if (value) {
+                        result.push({ LibraryId: input.getAttribute('data-library-id'), Emoji: value });
+                    }
+                });
+                return result;
+            }
+
+            function escapeHtml(value) {
+                return String(value === null || value === undefined ? '' : value)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#39;');
+            }
+
             function loadLibraries() {
                 // Return a promise to ensure libraries are loaded before rendering client configs
                 return ApiClient.getJSON(ApiClient.getUrl('Library/MediaFolders')).then(function (result) {
@@ -1610,6 +1727,7 @@
                     config.EmailConfigurations = emailConfigs;
                     config.RadarrConfigurations = radarrConfigs;
                     config.SonarrConfigurations = sonarrConfigs;
+                    config.LibraryEmojis = collectLibraryEmojis();
 
                     ApiClient.updatePluginConfiguration(NewsletterConfig.pluginUniqueId, config).then(function (result) {
                         Dashboard.processPluginConfigurationUpdateResult(result);
@@ -1866,6 +1984,7 @@
                         renderRadarrConfigs();
                         renderSonarrConfigs();
                         loadPreview();
+                        renderLibraryEmojis(config.LibraryEmojis || []);
                         Dashboard.hideLoadingMsg();
                     });
                 });

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -1615,8 +1615,8 @@
             // Mirrors LibraryEmojis.DefaultsByCollectionType on the server so the
             // placeholder shows the emoji that will actually be used.
             var EMOJI_DEFAULTS = {
-                movies: '🍿',
-                tvshows: '🎬',
+                movies: '🎬',
+                tvshows: '📺',
                 music: '🎵',
                 musicvideos: '🎤',
                 books: '📚',

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -93,9 +93,18 @@
                             The emoji shown beside each section heading in the newsletter, per library.
                             Leave a box empty to use the default for that library's type.
                             <br>
-                            Applies wherever a header template uses <b>{LibraryEmoji}</b> &mdash; the bundled
-                            templates do. If you have pasted your own Header HTML into a client below, add the
-                            placeholder there to pick these up.
+                            Two icons per heading: one for the event, one for the library, e.g.
+                            &quot;🎬 Added to 🍿 Movies&quot;. Leave a box empty to use its default.
+                            <br>
+                            The bundled templates use both. If you have pasted your own Header HTML into a
+                            client below, add <b>{EventEmoji}</b> and <b>{LibraryEmoji}</b> there to pick these up.
+                        </div>
+                        <div class="fieldDescription" style="margin-bottom: 8px;">
+                            Per event &mdash; shown by <b>{EventEmoji}</b>, at the start of the heading.
+                        </div>
+                        <div id="EventEmojiList" class="config-list" style="margin-bottom: 15px;"></div>
+                        <div class="fieldDescription" style="margin-bottom: 8px;">
+                            Per library &mdash; shown by <b>{LibraryEmoji}</b>, beside the library name.
                         </div>
                         <div id="LibraryEmojiList" class="config-list">
                             <p class="no-configs-text">Loading libraries&hellip;</p>
@@ -572,7 +581,8 @@
                 width: 30%;
             }
 
-            .emoji-lib-input input {
+            .emoji-lib-input input,
+            .emoji-lib-input input.event-emoji {
                 width: 100%;
                 font-size: 1.2em;
                 text-align: center;
@@ -1653,6 +1663,38 @@
                 return EMOJI_DEFAULTS[key] || EMOJI_FALLBACK;
             }
 
+            var EVENT_EMOJI_FIELDS = [
+                { key: 'EventEmojiAdd', label: 'Added', fallback: '\uD83C\uDFAC' },
+                { key: 'EventEmojiUpdate', label: 'Updated', fallback: '\uD83D\uDD04' },
+                { key: 'EventEmojiDelete', label: 'Removed', fallback: '\uD83D\uDDD1\uFE0F' },
+                { key: 'EventEmojiUpcoming', label: 'Upcoming', fallback: '\uD83D\uDCC5' }
+            ];
+
+            function renderEventEmojis(config) {
+                var container = document.getElementById('EventEmojiList');
+                if (!container) return;
+
+                var html = '<table class="emoji-table">';
+                EVENT_EMOJI_FIELDS.forEach(function (f) {
+                    html += '<tr>';
+                    html += '  <td class="emoji-lib-name">' + escapeHtml(f.label) + '</td>';
+                    html += '  <td class="emoji-lib-input"><input type="text" class="event-emoji"'
+                        + ' data-emoji-key="' + f.key + '"'
+                        + ' value="' + escapeHtml(config[f.key] || '') + '"'
+                        + ' placeholder="' + escapeHtml(f.fallback) + '" /></td>';
+                    html += '  <td class="emoji-lib-default">default ' + escapeHtml(f.fallback) + '</td>';
+                    html += '</tr>';
+                });
+                html += '</table>';
+                container.innerHTML = html;
+            }
+
+            function collectEventEmojis(config) {
+                document.querySelectorAll('.event-emoji').forEach(function (input) {
+                    config[input.getAttribute('data-emoji-key')] = (input.value || '').trim();
+                });
+            }
+
             function renderLibraryEmojis(configured) {
                 var container = document.getElementById('LibraryEmojiList');
                 if (!container) return;
@@ -1750,6 +1792,7 @@
                     config.RadarrConfigurations = radarrConfigs;
                     config.SonarrConfigurations = sonarrConfigs;
                     config.LibraryEmojis = collectLibraryEmojis();
+                    collectEventEmojis(config);
 
                     ApiClient.updatePluginConfiguration(NewsletterConfig.pluginUniqueId, config).then(function (result) {
                         Dashboard.processPluginConfigurationUpdateResult(result);
@@ -1762,15 +1805,6 @@
 
             var previewData = null;
             var previewExpanded = {};
-
-            function escapeHtml(value) {
-                return String(value === null || value === undefined ? '' : value)
-                    .replace(/&/g, '&amp;')
-                    .replace(/</g, '&lt;')
-                    .replace(/>/g, '&gt;')
-                    .replace(/"/g, '&quot;')
-                    .replace(/'/g, '&#39;');
-            }
 
             function previewGroupKey(group) {
                 return group.Title + ' ' + group.EventType;
@@ -2006,6 +2040,7 @@
                         renderRadarrConfigs();
                         renderSonarrConfigs();
                         loadPreview();
+                        renderEventEmojis(config);
                         renderLibraryEmojis(config.LibraryEmojis || []);
                         Dashboard.hideLoadingMsg();
                     });

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -576,6 +576,16 @@
                 width: 100%;
                 font-size: 1.2em;
                 text-align: center;
+                padding: 6px;
+                border-radius: 4px;
+                border: 1px solid #444;
+                background: rgba(255, 255, 255, 0.05);
+                color: inherit;
+            }
+
+            .emoji-lib-input input:focus {
+                outline: none;
+                border-color: #00a4dc;
             }
 
             .emoji-lib-default {
@@ -1650,7 +1660,7 @@
                     var fallback = defaultEmojiFor(lib.CollectionType);
                     html += '<tr>';
                     html += '  <td class="emoji-lib-name">' + escapeHtml(lib.Name) + '</td>';
-                    html += '  <td class="emoji-lib-input"><input type="text" is="emby-input" maxlength="8"'
+                    html += '  <td class="emoji-lib-input"><input type="text" maxlength="8"'
                         + ' class="library-emoji" data-library-id="' + escapeHtml(lib.Id) + '"'
                         + ' value="' + escapeHtml(byId[lib.Id] || '') + '"'
                         + ' placeholder="' + escapeHtml(fallback) + '" /></td>';

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -588,6 +588,18 @@
                 border-color: #00a4dc;
             }
 
+            /* The box is centre-aligned, so on an empty field the caret lands on top of the
+               centred placeholder and the default reads as real, uneditable content. Emoji
+               ignore the CSS color that normally greys a placeholder out, so fade it instead,
+               and hide it entirely on focus so the field is visibly empty while typing. */
+            .emoji-lib-input input::placeholder {
+                opacity: 0.4;
+            }
+
+            .emoji-lib-input input:focus::placeholder {
+                opacity: 0;
+            }
+
             .emoji-lib-default {
                 width: 25%;
                 opacity: 0.6;

--- a/Jellyfin.Plugin.Newsletters/Shared/EventEmojis.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/EventEmojis.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.Newsletters.Configuration;
+
+namespace Jellyfin.Plugin.Newsletters.Shared;
+
+/// <summary>
+/// Resolves the emoji shown in a newsletter section header for each event type.
+/// </summary>
+public static class EventEmojis
+{
+    /// <summary>
+    /// The emoji used when an event type has no configured value.
+    /// </summary>
+    public const string Fallback = "🎬";
+
+    /// <summary>
+    /// Gets the default emoji for an event type. These match what the bundled templates
+    /// hardcoded before the icons became configurable, so upgrading changes nothing on sight.
+    /// </summary>
+    /// <param name="eventType">The event type (add, update, delete, upcoming).</param>
+    /// <returns>The default emoji for that event type.</returns>
+    public static string DefaultFor(string? eventType)
+    {
+        return (eventType ?? string.Empty).ToLowerInvariant() switch
+        {
+            "add" => "🎬",
+            "update" => "🔄",
+            "delete" => "🗑️",
+            "upcoming" => "📅",
+            _ => Fallback
+        };
+    }
+
+    /// <summary>
+    /// Gets the emoji configured for an event type, falling back to its default when unset.
+    /// </summary>
+    /// <param name="eventType">The event type (add, update, delete, upcoming).</param>
+    /// <param name="config">The plugin configuration holding the overrides.</param>
+    /// <returns>The emoji to render.</returns>
+    public static string Resolve(string? eventType, PluginConfiguration config)
+    {
+        string? configured = (eventType ?? string.Empty).ToLowerInvariant() switch
+        {
+            "add" => config.EventEmojiAdd,
+            "update" => config.EventEmojiUpdate,
+            "delete" => config.EventEmojiDelete,
+            "upcoming" => config.EventEmojiUpcoming,
+            _ => null
+        };
+
+        return string.IsNullOrWhiteSpace(configured) ? DefaultFor(eventType) : configured.Trim();
+    }
+
+    /// <summary>
+    /// Gets the event types that carry a configurable emoji, in newsletter order.
+    /// </summary>
+    /// <returns>The event type keys.</returns>
+    public static IReadOnlyList<string> EventTypes()
+    {
+        return new[] { "add", "update", "delete", "upcoming" };
+    }
+}

--- a/Jellyfin.Plugin.Newsletters/Shared/LibraryEmojis.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/LibraryEmojis.cs
@@ -19,8 +19,8 @@ public static class LibraryEmojis
 
     private static readonly Dictionary<CollectionTypeOptions, string> DefaultsByCollectionType = new()
     {
-        { CollectionTypeOptions.movies, "🍿" },
-        { CollectionTypeOptions.tvshows, "🎬" },
+        { CollectionTypeOptions.movies, "🎬" },
+        { CollectionTypeOptions.tvshows, "📺" },
         { CollectionTypeOptions.music, "🎵" },
         { CollectionTypeOptions.musicvideos, "🎤" },
         { CollectionTypeOptions.books, "📚" },

--- a/Jellyfin.Plugin.Newsletters/Shared/LibraryEmojis.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/LibraryEmojis.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.Newsletters.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+
+namespace Jellyfin.Plugin.Newsletters.Shared;
+
+/// <summary>
+/// Resolves the emoji shown in a newsletter section header for each Jellyfin library.
+/// </summary>
+public static class LibraryEmojis
+{
+    /// <summary>
+    /// The emoji used when a library's collection type has no specific default.
+    /// </summary>
+    public const string Fallback = "🎞️";
+
+    private static readonly Dictionary<CollectionTypeOptions, string> DefaultsByCollectionType = new()
+    {
+        { CollectionTypeOptions.movies, "🍿" },
+        { CollectionTypeOptions.tvshows, "🎬" },
+        { CollectionTypeOptions.music, "🎵" },
+        { CollectionTypeOptions.musicvideos, "🎤" },
+        { CollectionTypeOptions.books, "📚" },
+        { CollectionTypeOptions.homevideos, "📹" },
+        { CollectionTypeOptions.boxsets, "📦" },
+        { CollectionTypeOptions.mixed, "🎞️" }
+    };
+
+    /// <summary>
+    /// Gets the default emoji for a collection type, used when the user has not set an override.
+    /// </summary>
+    /// <param name="collectionType">The library's collection type, if known.</param>
+    /// <returns>The default emoji for that collection type.</returns>
+    public static string DefaultFor(CollectionTypeOptions? collectionType)
+    {
+        if (collectionType.HasValue && DefaultsByCollectionType.TryGetValue(collectionType.Value, out var emoji))
+        {
+            return emoji;
+        }
+
+        return Fallback;
+    }
+
+    /// <summary>
+    /// Builds a dictionary mapping library name to the emoji its section headers should use.
+    /// </summary>
+    /// <remarks>
+    /// Keyed by name because that is all a section header has at render time, while the
+    /// configured overrides are keyed by library ID so that renaming a library keeps its emoji.
+    /// </remarks>
+    /// <param name="libraryManager">The Jellyfin library manager.</param>
+    /// <param name="logger">The logger used to report lookup failures.</param>
+    /// <param name="overrides">The user's per-library emoji overrides.</param>
+    /// <returns>A dictionary mapping library names to emoji. Empty if the lookup fails.</returns>
+    public static Dictionary<string, string> BuildMap(
+        ILibraryManager libraryManager,
+        Logger logger,
+        IEnumerable<LibraryEmojiConfiguration>? overrides)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        var overridesById = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var entry in overrides ?? Enumerable.Empty<LibraryEmojiConfiguration>())
+        {
+            if (!string.IsNullOrEmpty(entry.LibraryId) && !string.IsNullOrWhiteSpace(entry.Emoji))
+            {
+                overridesById[entry.LibraryId] = entry.Emoji.Trim();
+            }
+        }
+
+        try
+        {
+            foreach (var folder in libraryManager.GetVirtualFolders())
+            {
+                if (string.IsNullOrEmpty(folder.Name) || map.ContainsKey(folder.Name))
+                {
+                    continue;
+                }
+
+                map[folder.Name] = overridesById.TryGetValue(folder.ItemId ?? string.Empty, out var custom)
+                    ? custom
+                    : DefaultFor(folder.CollectionType);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"Error building library emoji map: {ex.Message}");
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Gets the emoji for a library name, falling back when the library is unknown.
+    /// </summary>
+    /// <param name="libraryName">The library name shown in the section header.</param>
+    /// <param name="map">The map produced by <see cref="BuildMap"/>.</param>
+    /// <returns>The emoji to render.</returns>
+    public static string Resolve(string? libraryName, Dictionary<string, string> map)
+    {
+        if (!string.IsNullOrEmpty(libraryName) && map.TryGetValue(libraryName, out var emoji))
+        {
+            return emoji;
+        }
+
+        return Fallback;
+    }
+}

--- a/Jellyfin.Plugin.Newsletters/Shared/LibraryEmojis.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/LibraryEmojis.cs
@@ -19,7 +19,7 @@ public static class LibraryEmojis
 
     private static readonly Dictionary<CollectionTypeOptions, string> DefaultsByCollectionType = new()
     {
-        { CollectionTypeOptions.movies, "🎬" },
+        { CollectionTypeOptions.movies, "🍿" },
         { CollectionTypeOptions.tvshows, "📺" },
         { CollectionTypeOptions.music, "🎵" },
         { CollectionTypeOptions.musicvideos, "🎤" },

--- a/Jellyfin.Plugin.Newsletters/Templates/Classic/template_header.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Classic/template_header.html
@@ -3,7 +3,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #E197BC; margin: 0; font-size: 1.8em; border-bottom: 2px solid #E197BC; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>🎬</span> Added to {LibraryName}
+                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Added to {LibraryName}
             </h2>
         </td>
     </tr>
@@ -14,7 +14,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #007fb1; margin: 0; font-size: 1.8em; border-bottom: 2px solid #007fb1; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>🔄</span> Updated in {LibraryName}
+                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Updated in {LibraryName}
             </h2>
         </td>
     </tr>
@@ -25,7 +25,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #d190c5; margin: 0; font-size: 1.8em; border-bottom: 2px solid #d190c5; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>🗑️</span> Removed from {LibraryName}
+                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Removed from {LibraryName}
             </h2>
         </td>
     </tr>
@@ -36,7 +36,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #bf7df0; margin: 0; font-size: 1.8em; border-bottom: 2px solid #bf7df0; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>📅</span> Upcoming in {LibraryName}
+                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Upcoming in {LibraryName}
             </h2>
         </td>
     </tr>

--- a/Jellyfin.Plugin.Newsletters/Templates/Classic/template_header.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Classic/template_header.html
@@ -3,7 +3,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #E197BC; margin: 0; font-size: 1.8em; border-bottom: 2px solid #E197BC; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Added to {LibraryName}
+                <span style='margin-right: 4px;'>{EventEmoji}</span> Added to {LibraryEmoji} {LibraryName}
             </h2>
         </td>
     </tr>
@@ -14,7 +14,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #007fb1; margin: 0; font-size: 1.8em; border-bottom: 2px solid #007fb1; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Updated in {LibraryName}
+                <span style='margin-right: 4px;'>{EventEmoji}</span> Updated in {LibraryEmoji} {LibraryName}
             </h2>
         </td>
     </tr>
@@ -25,7 +25,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #d190c5; margin: 0; font-size: 1.8em; border-bottom: 2px solid #d190c5; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Removed from {LibraryName}
+                <span style='margin-right: 4px;'>{EventEmoji}</span> Removed from {LibraryEmoji} {LibraryName}
             </h2>
         </td>
     </tr>
@@ -36,7 +36,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #bf7df0; margin: 0; font-size: 1.8em; border-bottom: 2px solid #bf7df0; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Upcoming in {LibraryName}
+                <span style='margin-right: 4px;'>{EventEmoji}</span> Upcoming in {LibraryEmoji} {LibraryName}
             </h2>
         </td>
     </tr>

--- a/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_header.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_header.html
@@ -1,15 +1,15 @@
 <template id="header-add">
-<h2><font data-mx-color='#4CAF50'>🎬 Added to {LibraryName}</font></h2><hr/>
+<h2><font data-mx-color='#4CAF50'>{EventEmoji} Added to {LibraryEmoji} {LibraryName}</font></h2><hr/>
 </template>
 
 <template id="header-update">
-<h2><font data-mx-color='#2196F3'>🔄 Updated in {LibraryName}</font></h2><hr/>
+<h2><font data-mx-color='#2196F3'>{EventEmoji} Updated in {LibraryEmoji} {LibraryName}</font></h2><hr/>
 </template>
 
 <template id="header-delete">
-<h2><font data-mx-color='#F44336'>🗑️ Removed from {LibraryName}</font></h2><hr/>
+<h2><font data-mx-color='#F44336'>{EventEmoji} Removed from {LibraryEmoji} {LibraryName}</font></h2><hr/>
 </template>
 
 <template id="header-upcoming">
-<h2><font data-mx-color='#FF8C00'>📅 Upcoming in {LibraryName}</font></h2><hr/>
+<h2><font data-mx-color='#FF8C00'>{EventEmoji} Upcoming in {LibraryEmoji} {LibraryName}</font></h2><hr/>
 </template>

--- a/Jellyfin.Plugin.Newsletters/Templates/Modern/template_header.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Modern/template_header.html
@@ -3,7 +3,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #4CAF50; margin: 0; font-size: 1.8em; border-bottom: 2px solid #4CAF50; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Added to {LibraryName}
+                <span style='margin-right: 4px;'>{EventEmoji}</span> Added to {LibraryEmoji} {LibraryName}
             </h2>
         </td>
     </tr>
@@ -14,7 +14,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #2196F3; margin: 0; font-size: 1.8em; border-bottom: 2px solid #2196F3; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Updated in {LibraryName}
+                <span style='margin-right: 4px;'>{EventEmoji}</span> Updated in {LibraryEmoji} {LibraryName}
             </h2>
         </td>
     </tr>
@@ -25,7 +25,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #F44336; margin: 0; font-size: 1.8em; border-bottom: 2px solid #F44336; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Removed from {LibraryName}
+                <span style='margin-right: 4px;'>{EventEmoji}</span> Removed from {LibraryEmoji} {LibraryName}
             </h2>
         </td>
     </tr>
@@ -36,7 +36,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #FF8C00; margin: 0; font-size: 1.8em; border-bottom: 2px solid #FF8C00; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Upcoming in {LibraryName}
+                <span style='margin-right: 4px;'>{EventEmoji}</span> Upcoming in {LibraryEmoji} {LibraryName}
             </h2>
         </td>
     </tr>

--- a/Jellyfin.Plugin.Newsletters/Templates/Modern/template_header.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Modern/template_header.html
@@ -3,7 +3,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #4CAF50; margin: 0; font-size: 1.8em; border-bottom: 2px solid #4CAF50; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>🎬</span> Added to {LibraryName}
+                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Added to {LibraryName}
             </h2>
         </td>
     </tr>
@@ -14,7 +14,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #2196F3; margin: 0; font-size: 1.8em; border-bottom: 2px solid #2196F3; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>🔄</span> Updated in {LibraryName}
+                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Updated in {LibraryName}
             </h2>
         </td>
     </tr>
@@ -25,7 +25,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #F44336; margin: 0; font-size: 1.8em; border-bottom: 2px solid #F44336; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>🗑️</span> Removed from {LibraryName}
+                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Removed from {LibraryName}
             </h2>
         </td>
     </tr>
@@ -36,7 +36,7 @@
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
                 style='color: #FF8C00; margin: 0; font-size: 1.8em; border-bottom: 2px solid #FF8C00; padding-bottom: 10px; display: flex;'>
-                <span style='margin-right: 4px;'>📅</span> Upcoming in {LibraryName}
+                <span style='margin-right: 4px;'>{LibraryEmoji}</span> Upcoming in {LibraryName}
             </h2>
         </td>
     </tr>


### PR DESCRIPTION
Closes #110.

## What this adds

Each library gets its own emoji in newsletter section headings, instead of every heading of a given event type sharing one hardcoded icon.

Before, a multi-library server produced:

```
🎬 Added to Movies      🎬 Added to Shows      🎬 Added to Anime
```

After:

```
🎬 Added to Movies      📺 Added to Shows      🗾 Added to Anime
```

The event type is still conveyed by the verb and by each header's existing colour, so nothing is lost by making the icon library-specific.

## How it works

- **`{LibraryEmoji}` placeholder**, resolved in `HtmlContentBuilder.GetEventSectionHeader` right beside the existing `{LibraryName}` substitution. That method is the single choke point for HTML section headers, so Email and Matrix both pick it up.
- **Defaults come from the library's collection type**, so it looks right with no configuration: 🎬 `movies`, 📺 `tvshows`, 🎵 `music`, 🎤 `musicvideos`, 📚 `books`, 📹 `homevideos`, 📦 `boxsets`, with 🎞️ as the fallback for anything else.
- **Per-library overrides** live in `PluginConfiguration.LibraryEmojis`, keyed by **library ID** so renaming a library keeps its emoji. The lookup map is keyed by name, because the library name is all a section header has at render time — `Shared/LibraryEmojis.BuildMap` bridges the two.
- **The map is built once per newsletter run**, cached on `ClientBuilder` rather than rebuilt per section.
- **Settings UI** is a "Section Emojis" table in the General tab: one row per library, with the collection-type default shown as both the input placeholder and a hint, so leaving a box empty visibly means "use the default".

## Compatibility

- The bundled Classic and Modern header templates are updated to use the placeholder.
- **Anyone with custom Header HTML is unaffected** — the plugin only falls back to the bundled templates when the config field is blank, so an existing custom header keeps its literal emoji until the user adds `{LibraryEmoji}` themselves. The settings UI says this.
- No schema or config migration: `LibraryEmojis` defaults to empty, which means "use the defaults everywhere".

## Testing

Verified against the compiled assembly:

- Each of the 7 mapped collection types returns its intended emoji.
- **Every value of `CollectionTypeOptions` returns a non-empty emoji**, so a collection type added by a future Jellyfin release renders the fallback rather than a blank span.
- A null collection type returns the fallback.
- Name lookup: exact hit, configured override, unknown library, and null name all resolve as intended.

Also confirmed the project builds clean (0 warnings, 0 errors) and the settings page JavaScript parses.

Also verified against a **live send** on Jellyfin 10.11.11: with a Header template containing the placeholder, the plugin's test mail rendered the emoji in all four section headers (added / updated / removed / upcoming) with no literal `{LibraryEmoji}` left behind.

That send exercises the fallback branch specifically — the test path renders a synthetic item with no real library, so every header correctly resolved to 🎞️ rather than a per-library icon. The per-library mapping itself is covered by the checks above rather than by that send.

Per CONTRIBUTING.md, this was built locally against ImageSharp 3.1.12; the downgrade was kept out of the diff.
