### PR TITLE
Featured section: pin hand-picked library items to the top of the newsletter

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Clients/Client.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Client.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Newsletters.Configuration;
+using Jellyfin.Plugin.Newsletters.Featured;
 using Jellyfin.Plugin.Newsletters.Integrations;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
 using Jellyfin.Plugin.Newsletters.Shared.Entities;
@@ -67,6 +68,7 @@ public class Client(Logger loggerInstance,
             {
                 Logger.Info($"Clearing {Config.FeaturedItemIds.Count} featured item(s) after send");
                 Config.FeaturedItemIds.Clear();
+                FeaturedItems.ClearPosterCache();
             }
 
             // Update and save the last published date

--- a/Jellyfin.Plugin.Newsletters/Clients/Client.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Client.cs
@@ -61,6 +61,14 @@ public class Client(Logger loggerInstance,
             Db.ExecuteSQL("INSERT OR REPLACE INTO ArchiveData SELECT * FROM CurrNewsletterData;");
             Db.ExecuteSQL("DELETE FROM CurrNewsletterData;");
 
+            // Featured picks are curated per issue, so a send consumes them the same way it
+            // consumes the queue. Leaving them would silently re-run the same feature forever.
+            if (Config.FeaturedItemIds.Count > 0)
+            {
+                Logger.Info($"Clearing {Config.FeaturedItemIds.Count} featured item(s) after send");
+                Config.FeaturedItemIds.Clear();
+            }
+
             // Update and save the last published date
             Config.LastPublishedDate = DateTime.Now;
             Plugin.Instance!.SaveConfiguration();
@@ -118,6 +126,8 @@ public class Client(Logger loggerInstance,
         bool dbPopulated = NewsletterDbIsPopulated();
         var upcomingItems = await UpcomingService.GetAllUpcomingAsync().ConfigureAwait(false);
         
-        return (dbPopulated || upcomingItems.Count > 0, upcomingItems);
+        bool hasFeatured = Config.FeaturedItemIds.Count > 0;
+
+        return (dbPopulated || hasFeatured || upcomingItems.Count > 0, upcomingItems);
     }
 }

--- a/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
@@ -111,11 +111,18 @@ public class ClientBuilder(Logger loggerInstance,
                 continue;
             }
 
-            string featuredKey = $"{item.Title}_{FeaturedItems.EventType}";
-            if (!itemsByKey.ContainsKey(featuredKey))
+            // A featured title is very often also sitting in the queue (featuring something added
+            // this week is the common case). Drop those rows so the title is rendered once, under
+            // the Featured heading, instead of appearing again under its library section.
+            foreach (var duplicateKey in itemsByKey
+                .Where(kvp => string.Equals(kvp.Value.Title, item.Title, StringComparison.OrdinalIgnoreCase))
+                .Select(kvp => kvp.Key)
+                .ToList())
             {
-                itemsByKey[featuredKey] = item;
+                itemsByKey.Remove(duplicateKey);
             }
+
+            itemsByKey[$"{item.Title}_{FeaturedItems.EventType}"] = item;
         }
 
         // Append prefetched upcoming items and deduplicate by title

--- a/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Jellyfin.Plugin.Newsletters.Configuration;
+using Jellyfin.Plugin.Newsletters.Featured;
 using Jellyfin.Plugin.Newsletters.Shared;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
 using Jellyfin.Plugin.Newsletters.Shared.Entities;
@@ -24,6 +25,8 @@ public class ClientBuilder(Logger loggerInstance,
     SQLiteDatabase dbInstance,
     ILibraryManager libraryManagerInstance)
 {
+    private IReadOnlyList<JsonFileObj>? featuredEntries;
+
     /// <summary>
     /// Gets the plugin configuration instance.
     /// </summary>
@@ -43,6 +46,12 @@ public class ClientBuilder(Logger loggerInstance,
     /// Gets the library manager instance.
     /// </summary>
     protected ILibraryManager LibraryManager { get; } = libraryManagerInstance;
+
+    /// <summary>
+    /// Gets the admin's pinned featured entries, resolved once per newsletter run.
+    /// </summary>
+    protected IReadOnlyList<JsonFileObj> FeaturedEntries =>
+        featuredEntries ??= FeaturedItems.Build(LibraryManager, Logger, Config.Hostname, Config.FeaturedItemIds);
 
     /// <summary>
     /// Queries newsletter data from the database, merges upcoming items, deduplicates,
@@ -93,6 +102,22 @@ public class ClientBuilder(Logger loggerInstance,
             Db.CloseConnection();
         }
 
+        // Prepend the admin's featured picks. They are resolved from the library rather than the
+        // queue, so they bypass the queue entirely but still honour this client's filters.
+        foreach (var item in FeaturedEntries)
+        {
+            if (!ShouldIncludeItem(item, config, clientName))
+            {
+                continue;
+            }
+
+            string featuredKey = $"{item.Title}_{FeaturedItems.EventType}";
+            if (!itemsByKey.ContainsKey(featuredKey))
+            {
+                itemsByKey[featuredKey] = item;
+            }
+        }
+
         // Append prefetched upcoming items and deduplicate by title
         if (upcomingItems != null && upcomingItems.Count > 0)
         {
@@ -111,7 +136,7 @@ public class ClientBuilder(Logger loggerInstance,
 
         var allItems = itemsByKey.Values.ToList();
 
-        var eventTypeOrder = new Dictionary<string, int> { { "add", 0 }, { "update", 1 }, { "delete", 2 }, { "upcoming", 3 } };
+        var eventTypeOrder = new Dictionary<string, int> { { "featured", 0 }, { "add", 1 }, { "update", 2 }, { "delete", 3 }, { "upcoming", 4 } };
 
         return allItems
             .OrderBy(i => eventTypeOrder.GetValueOrDefault(i.EventType?.ToLowerInvariant() ?? "add", 0))
@@ -468,6 +493,7 @@ public class ClientBuilder(Logger loggerInstance,
             "delete" => $"🗑️ Removed from {libDisplay}",
             "update" => $"🔄 Updated in {libDisplay}",
             "upcoming" => $"📅 Upcoming in {libDisplay}",
+            "featured" => $"{Config.FeaturedEmoji} Featured",
             _ => $"🎬 Added to {libDisplay}"
         };
     }
@@ -492,6 +518,11 @@ public class ClientBuilder(Logger loggerInstance,
         else if (eventType == "update" && !config.NewsletterOnItemUpdatedEnabled)
         {
             Logger.Debug($"[{clientName}] Skipping item '{item.Title}' (Event: {eventType}) - 'Item Updated' notifications disabled.");
+            return false;
+        }
+        else if (eventType == FeaturedItems.EventType && !config.NewsletterOnFeaturedEnabled)
+        {
+            Logger.Debug($"[{clientName}] Skipping item '{item.Title}' (Event: {eventType}) - 'Featured' section disabled.");
             return false;
         }
         else if (eventType == "delete" && !config.NewsletterOnItemDeletedEnabled)

--- a/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/ClientBuilder.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using Jellyfin.Plugin.Newsletters.Configuration;
 using Jellyfin.Plugin.Newsletters.Featured;
+using Jellyfin.Plugin.Newsletters.Scanner;
 using Jellyfin.Plugin.Newsletters.Shared;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
 using Jellyfin.Plugin.Newsletters.Shared.Entities;
@@ -51,7 +52,7 @@ public class ClientBuilder(Logger loggerInstance,
     /// Gets the admin's pinned featured entries, resolved once per newsletter run.
     /// </summary>
     protected IReadOnlyList<JsonFileObj> FeaturedEntries =>
-        featuredEntries ??= FeaturedItems.Build(LibraryManager, Logger, Config.Hostname, Config.FeaturedItemIds);
+        featuredEntries ??= FeaturedItems.Build(LibraryManager, Logger, Db, new PosterImageHandler(Logger), Config.Hostname, Config.FeaturedItemIds);
 
     /// <summary>
     /// Queries newsletter data from the database, merges upcoming items, deduplicates,

--- a/Jellyfin.Plugin.Newsletters/Clients/Discord/EmbedBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Discord/EmbedBuilder.cs
@@ -277,11 +277,6 @@ public class EmbedBuilder(
 
         var eventLower = eventType.ToLowerInvariant();
 
-        if (eventLower == "upcoming")
-        {
-            return Convert.ToInt32("FF8C00", 16); // Orange for upcoming items
-        }
-        
         if (mediaType == "Series")
         {
             return eventLower switch
@@ -289,6 +284,8 @@ public class EmbedBuilder(
                 "add" => Convert.ToInt32(discordConfig.SeriesAddEmbedColor.Replace("#", string.Empty, StringComparison.Ordinal), 16),
                 "delete" => Convert.ToInt32(discordConfig.SeriesDeleteEmbedColor.Replace("#", string.Empty, StringComparison.Ordinal), 16),
                 "update" => Convert.ToInt32(discordConfig.SeriesUpdateEmbedColor.Replace("#", string.Empty, StringComparison.Ordinal), 16),
+                "upcoming" => Convert.ToInt32(discordConfig.SeriesUpcomingEmbedColor.Replace("#", string.Empty, StringComparison.Ordinal), 16),
+                "featured" => Convert.ToInt32(discordConfig.SeriesFeaturedEmbedColor.Replace("#", string.Empty, StringComparison.Ordinal), 16),
                 _ => Convert.ToInt32(discordConfig.SeriesAddEmbedColor.Replace("#", string.Empty, StringComparison.Ordinal), 16)
             };
         }
@@ -299,6 +296,8 @@ public class EmbedBuilder(
                 "add" => Convert.ToInt32(discordConfig.MoviesAddEmbedColor.Replace("#", string.Empty, StringComparison.Ordinal), 16),
                 "delete" => Convert.ToInt32(discordConfig.MoviesDeleteEmbedColor.Replace("#", string.Empty, StringComparison.Ordinal), 16),
                 "update" => Convert.ToInt32(discordConfig.MoviesUpdateEmbedColor.Replace("#", string.Empty, StringComparison.Ordinal), 16),
+                "upcoming" => Convert.ToInt32(discordConfig.MoviesUpcomingEmbedColor.Replace("#", string.Empty, StringComparison.Ordinal), 16),
+                "featured" => Convert.ToInt32(discordConfig.MoviesFeaturedEmbedColor.Replace("#", string.Empty, StringComparison.Ordinal), 16),
                 _ => Convert.ToInt32(discordConfig.MoviesAddEmbedColor.Replace("#", string.Empty, StringComparison.Ordinal), 16)
             };
         }

--- a/Jellyfin.Plugin.Newsletters/Clients/Discord/EmbedBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Discord/EmbedBuilder.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Jellyfin.Plugin.Newsletters.Configuration;
+using Jellyfin.Plugin.Newsletters.Featured;
 using Jellyfin.Plugin.Newsletters.Integrations;
 using Jellyfin.Plugin.Newsletters.Shared;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
@@ -61,7 +62,11 @@ public class EmbedBuilder(
                 // Skip items beyond the per-section cap
                 if (maxItemsPerSection > 0)
                 {
-                    string sectionKey = $"{eventType}|{libraryName}";
+                    // Featured picks form a single section spanning libraries, the way the HTML
+                    // clients group them, so the cap applies to that whole section.
+                    string sectionKey = eventType == FeaturedItems.EventType
+                        ? $"{eventType}|{FeaturedItems.SectionName}"
+                        : $"{eventType}|{libraryName}";
                     sectionItemCounts.TryGetValue(sectionKey, out int sectionItemCount);
                     sectionItemCounts[sectionKey] = sectionItemCount + 1;
 
@@ -318,6 +323,7 @@ public class EmbedBuilder(
         return basePrefix.Replace($"Added to {libDisplay}", $"**Added to {libDisplay}**", StringComparison.Ordinal)
                         .Replace($"Removed from {libDisplay}", $"**Removed from {libDisplay}**", StringComparison.Ordinal)
                         .Replace($"Updated in {libDisplay}", $"**Updated in {libDisplay}**", StringComparison.Ordinal)
-                        .Replace($"Upcoming in {libDisplay}", $"**Upcoming in {libDisplay}**", StringComparison.Ordinal);
+                        .Replace($"Upcoming in {libDisplay}", $"**Upcoming in {libDisplay}**", StringComparison.Ordinal)
+                        .Replace($"{Config.FeaturedEmoji} {FeaturedItems.SectionName}", $"{Config.FeaturedEmoji} **{FeaturedItems.SectionName}**", StringComparison.Ordinal);
     }
 }

--- a/Jellyfin.Plugin.Newsletters/Clients/Email/HTMLBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Email/HTMLBuilder.cs
@@ -256,7 +256,7 @@ public class HtmlBuilder(
             "update" => ("UPDATED", "🔄", "#2196F3"),
             "delete" => ("REMOVED", "🗑️", "#F44336"),
             "upcoming" => ("UPCOMING", "📅", "#FF8C00"),
-            "featured" => ("FEATURED", Config.FeaturedEmoji, "#8E24AA"),
+            "featured" => ("FEATURED", Config.FeaturedEmoji, "#FFC107"),
             _ => ("NEW", "🎬", "#4CAF50")
         };
 

--- a/Jellyfin.Plugin.Newsletters/Clients/Email/HTMLBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Email/HTMLBuilder.cs
@@ -256,6 +256,7 @@ public class HtmlBuilder(
             "update" => ("UPDATED", "🔄", "#2196F3"),
             "delete" => ("REMOVED", "🗑️", "#F44336"),
             "upcoming" => ("UPCOMING", "📅", "#FF8C00"),
+            "featured" => ("FEATURED", Config.FeaturedEmoji, "#8E24AA"),
             _ => ("NEW", "🎬", "#4CAF50")
         };
 

--- a/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
@@ -247,7 +247,15 @@ public abstract class HtmlContentBuilder(
     protected IEnumerable<EventGroupResult> BuildGroupedItems(INewsletterConfiguration config, string clientName)
     {
         var libraryNameMap = LibraryNames.BuildMap(LibraryManager, Logger);
-        var sortedItems = BuildSortedItems(config, UpcomingItems, clientName);
+        IEnumerable<JsonFileObj> sortedItems = BuildSortedItems(config, UpcomingItems, clientName);
+
+        // A custom header saved before the Featured section existed carries no header-featured
+        // template. Drop the picks rather than emitting them under no heading at all.
+        if (string.IsNullOrWhiteSpace(this.headerFeaturedHtml))
+        {
+            Logger.Warn($"[{clientName}] Header HTML has no 'header-featured' section - skipping the Featured section.");
+            sortedItems = sortedItems.Where(i => !string.Equals(i.EventType, FeaturedItems.EventType, StringComparison.OrdinalIgnoreCase));
+        }
 
         return sortedItems
             .GroupBy(i => i.EventType?.ToLowerInvariant() ?? "add")
@@ -332,6 +340,11 @@ public abstract class HtmlContentBuilder(
         for (int i = 0; i < eventTypes.Length; i++)
         {
             string eventType = eventTypes[i];
+
+            if (eventType == FeaturedItems.EventType && string.IsNullOrWhiteSpace(this.headerFeaturedHtml))
+            {
+                continue;
+            }
 
             testHTML.Append(GetEventSectionHeader(eventType));
 
@@ -473,7 +486,7 @@ public abstract class HtmlContentBuilder(
         this.headerUpcomingHtml = ExtractTemplateSection(fullHeaderHtml, "header-upcoming");
         this.headerFeaturedHtml = ExtractTemplateSection(fullHeaderHtml, "header-featured");
 
-        Logger.Debug($"Header sections parsed — Add: {!string.IsNullOrEmpty(this.headerAddHtml)}, Update: {!string.IsNullOrEmpty(this.headerUpdateHtml)}, Delete: {!string.IsNullOrEmpty(this.headerDeleteHtml)}, Upcoming: {!string.IsNullOrEmpty(this.headerUpcomingHtml)}");
+        Logger.Debug($"Header sections parsed — Featured: {!string.IsNullOrEmpty(this.headerFeaturedHtml)}, Add: {!string.IsNullOrEmpty(this.headerAddHtml)}, Update: {!string.IsNullOrEmpty(this.headerUpdateHtml)}, Delete: {!string.IsNullOrEmpty(this.headerDeleteHtml)}, Upcoming: {!string.IsNullOrEmpty(this.headerUpcomingHtml)}");
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Jellyfin.Plugin.Newsletters.Configuration;
+using Jellyfin.Plugin.Newsletters.Featured;
 using Jellyfin.Plugin.Newsletters.Integrations;
 using Jellyfin.Plugin.Newsletters.Shared;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
@@ -36,6 +37,7 @@ public abstract class HtmlContentBuilder(
     private string headerUpdateHtml = string.Empty;
     private string headerDeleteHtml = string.Empty;
     private string headerUpcomingHtml = string.Empty;
+    private string headerFeaturedHtml = string.Empty;
     private bool _isSetup;
 
     /// <summary>
@@ -63,6 +65,7 @@ public abstract class HtmlContentBuilder(
             "update" => headerUpdateHtml,
             "delete" => headerDeleteHtml,
             "upcoming" => headerUpcomingHtml,
+            "featured" => headerFeaturedHtml,
             _ => headerAddHtml
         };
 
@@ -72,7 +75,8 @@ public abstract class HtmlContentBuilder(
             return string.Empty;
         }
 
-        return this.TemplateReplace(headerTemplate, "{LibraryName}", libraryName);
+        string header = this.TemplateReplace(headerTemplate, "{LibraryName}", libraryName);
+        return this.TemplateReplace(header, "{FeaturedEmoji}", Config.FeaturedEmoji);
     }
 
     /// <summary>
@@ -251,7 +255,9 @@ public abstract class HtmlContentBuilder(
             {
                 EventType = eventGroup.Key,
                 Libraries = eventGroup
-                    .GroupBy(i => i.EventType == "upcoming" ? i.LibraryId : LibraryNames.Resolve(i.LibraryId, libraryNameMap))
+                    .GroupBy(i => i.EventType == FeaturedItems.EventType
+                        ? FeaturedItems.SectionName
+                        : i.EventType == "upcoming" ? i.LibraryId : LibraryNames.Resolve(i.LibraryId, libraryNameMap))
                     .Select(libGroup => new LibraryGroupResult { LibraryName = libGroup.Key, Items = libGroup.ToList() })
             });
     }
@@ -320,8 +326,8 @@ public abstract class HtmlContentBuilder(
 
         StringBuilder testHTML = new StringBuilder();
 
-        string[] eventTypes = { "add", "update", "delete", "upcoming" };
-        string[] titles = { "Test Added Series", "Test Updated Movie", "Test Deleted Series", "Test Upcoming Movie" };
+        string[] eventTypes = { FeaturedItems.EventType, "add", "update", "delete", "upcoming" };
+        string[] titles = { "Test Featured Movie", "Test Added Series", "Test Updated Movie", "Test Deleted Series", "Test Upcoming Movie" };
 
         for (int i = 0; i < eventTypes.Length; i++)
         {
@@ -465,6 +471,7 @@ public abstract class HtmlContentBuilder(
         this.headerUpdateHtml = ExtractTemplateSection(fullHeaderHtml, "header-update");
         this.headerDeleteHtml = ExtractTemplateSection(fullHeaderHtml, "header-delete");
         this.headerUpcomingHtml = ExtractTemplateSection(fullHeaderHtml, "header-upcoming");
+        this.headerFeaturedHtml = ExtractTemplateSection(fullHeaderHtml, "header-featured");
 
         Logger.Debug($"Header sections parsed — Add: {!string.IsNullOrEmpty(this.headerAddHtml)}, Update: {!string.IsNullOrEmpty(this.headerUpdateHtml)}, Delete: {!string.IsNullOrEmpty(this.headerDeleteHtml)}, Upcoming: {!string.IsNullOrEmpty(this.headerUpcomingHtml)}");
     }

--- a/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixMessageBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixMessageBuilder.cs
@@ -159,6 +159,7 @@ public class MatrixMessageBuilder(
             "update" => ("UPDATED", "🔄", "#2196F3"),
             "delete" => ("REMOVED", "🗑️", "#F44336"),
             "upcoming" => ("UPCOMING", "📅", "#FF8C00"),
+            "featured" => ("FEATURED", Config.FeaturedEmoji, "#8E24AA"),
             _ => ("NEW", "🎬", "#4CAF50")
         };
 

--- a/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixMessageBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixMessageBuilder.cs
@@ -159,7 +159,7 @@ public class MatrixMessageBuilder(
             "update" => ("UPDATED", "🔄", "#2196F3"),
             "delete" => ("REMOVED", "🗑️", "#F44336"),
             "upcoming" => ("UPCOMING", "📅", "#FF8C00"),
-            "featured" => ("FEATURED", Config.FeaturedEmoji, "#8E24AA"),
+            "featured" => ("FEATURED", Config.FeaturedEmoji, "#FFC107"),
             _ => ("NEW", "🎬", "#4CAF50")
         };
 

--- a/Jellyfin.Plugin.Newsletters/Clients/Telegram/TelegramMessageBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Telegram/TelegramMessageBuilder.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Jellyfin.Plugin.Newsletters.Configuration;
+using Jellyfin.Plugin.Newsletters.Featured;
 using Jellyfin.Plugin.Newsletters.Integrations;
 using Jellyfin.Plugin.Newsletters.Shared;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
@@ -84,7 +85,11 @@ public class TelegramMessageBuilder(
                 // Skip items beyond the per-section cap
                 if (maxItemsPerSection > 0)
                 {
-                    string sectionKey = $"{eventType}|{libraryName}";
+                    // Featured picks form a single section spanning libraries, the way the HTML
+                    // clients group them, so the cap applies to that whole section.
+                    string sectionKey = eventType == FeaturedItems.EventType
+                        ? $"{eventType}|{FeaturedItems.SectionName}"
+                        : $"{eventType}|{libraryName}";
                     sectionItemCounts.TryGetValue(sectionKey, out int sectionItemCount);
                     sectionItemCounts[sectionKey] = sectionItemCount + 1;
 

--- a/Jellyfin.Plugin.Newsletters/Configuration/DiscordConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/DiscordConfiguration.cs
@@ -129,6 +129,11 @@ public class DiscordConfiguration : INewsletterConfiguration
     public bool NewsletterOnUpcomingItemEnabled { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets a value indicating whether to include the featured section in the newsletter.
+    /// </summary>
+    public bool NewsletterOnFeaturedEnabled { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the maximum number of items shown per newsletter section.
     /// A value of 0 means unlimited (default).
     /// </summary>

--- a/Jellyfin.Plugin.Newsletters/Configuration/DiscordConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/DiscordConfiguration.cs
@@ -84,6 +84,16 @@ public class DiscordConfiguration : INewsletterConfiguration
     public string SeriesUpdateEmbedColor { get; set; } = "#0000ff";
 
     /// <summary>
+    /// Gets or sets the embed color for series upcoming events.
+    /// </summary>
+    public string SeriesUpcomingEmbedColor { get; set; } = "#ff8c00";
+
+    /// <summary>
+    /// Gets or sets the embed color for series featured events.
+    /// </summary>
+    public string SeriesFeaturedEmbedColor { get; set; } = "#ffc107";
+
+    /// <summary>
     /// Gets or sets the embed color for movies add events.
     /// </summary>
     public string MoviesAddEmbedColor { get; set; } = "#00ff00";
@@ -97,6 +107,16 @@ public class DiscordConfiguration : INewsletterConfiguration
     /// Gets or sets the embed color for movies update events.
     /// </summary>
     public string MoviesUpdateEmbedColor { get; set; } = "#0000ff";
+
+    /// <summary>
+    /// Gets or sets the embed color for movies upcoming events.
+    /// </summary>
+    public string MoviesUpcomingEmbedColor { get; set; } = "#ff8c00";
+
+    /// <summary>
+    /// Gets or sets the embed color for movies featured events.
+    /// </summary>
+    public string MoviesFeaturedEmbedColor { get; set; } = "#ffc107";
 
     /// <summary>
     /// Gets or sets the collection of selected series libraries.

--- a/Jellyfin.Plugin.Newsletters/Configuration/EmailConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/EmailConfiguration.cs
@@ -116,6 +116,11 @@ public class EmailConfiguration : ITemplatedConfiguration
     public bool NewsletterOnUpcomingItemEnabled { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets a value indicating whether to include the featured section in the newsletter.
+    /// </summary>
+    public bool NewsletterOnFeaturedEnabled { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets a value indicating whether SSL is enabled for the SMTP connection.
     /// </summary>
     public bool EnableSsl { get; set; } = true;

--- a/Jellyfin.Plugin.Newsletters/Configuration/INewsletterConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/INewsletterConfiguration.cs
@@ -43,6 +43,11 @@ public interface INewsletterConfiguration
     bool NewsletterOnUpcomingItemEnabled { get; }
 
     /// <summary>
+    /// Gets a value indicating whether to include the featured section in the newsletter.
+    /// </summary>
+    bool NewsletterOnFeaturedEnabled { get; }
+
+    /// <summary>
     /// Gets the maximum number of items shown per newsletter section.
     /// A value of 0 means unlimited.
     /// </summary>

--- a/Jellyfin.Plugin.Newsletters/Configuration/MatrixConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/MatrixConfiguration.cs
@@ -90,6 +90,11 @@ public class MatrixConfiguration : ITemplatedConfiguration
     public bool NewsletterOnUpcomingItemEnabled { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets a value indicating whether to include the featured section in the newsletter.
+    /// </summary>
+    public bool NewsletterOnFeaturedEnabled { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the maximum number of items shown per newsletter section.
     /// A value of 0 means unlimited (default).
     /// </summary>

--- a/Jellyfin.Plugin.Newsletters/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/PluginConfiguration.cs
@@ -481,6 +481,17 @@ public class PluginConfiguration : BasePluginConfiguration
     public Collection<RadarrConfiguration> RadarrConfigurations { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets the Jellyfin item IDs pinned to the featured section of the next newsletter.
+    /// Cleared once a newsletter is sent, so each issue is curated deliberately.
+    /// </summary>
+    public Collection<string> FeaturedItemIds { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the emoji shown beside the featured section heading.
+    /// </summary>
+    public string FeaturedEmoji { get; set; } = "\u2B50";
+
+    /// <summary>
     /// Gets or sets the collection of Sonarr instance configurations.
     /// </summary>
     public Collection<SonarrConfiguration> SonarrConfigurations { get; set; } = new();

--- a/Jellyfin.Plugin.Newsletters/Configuration/TelegramConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/TelegramConfiguration.cs
@@ -99,6 +99,11 @@ public class TelegramConfiguration : INewsletterConfiguration
     public bool NewsletterOnUpcomingItemEnabled { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets a value indicating whether to include the featured section in the newsletter.
+    /// </summary>
+    public bool NewsletterOnFeaturedEnabled { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the maximum number of items shown per newsletter section.
     /// A value of 0 means unlimited (default).
     /// </summary>

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -922,9 +922,13 @@
                     SeriesAddEmbedColor: '#00FF00',
                     SeriesDeleteEmbedColor: '#FF0000',
                     SeriesUpdateEmbedColor: '#0000FF',
+                    SeriesUpcomingEmbedColor: '#FF8C00',
+                    SeriesFeaturedEmbedColor: '#FFC107',
                     MoviesAddEmbedColor: '#00FF00',
                     MoviesDeleteEmbedColor: '#FF0000',
                     MoviesUpdateEmbedColor: '#0000FF',
+                    MoviesUpcomingEmbedColor: '#FF8C00',
+                    MoviesFeaturedEmbedColor: '#FFC107',
                     SelectedSeriesLibraries: [],
                     SelectedMoviesLibraries: [],
                     NewsletterOnItemAddedEnabled: true,
@@ -990,9 +994,13 @@
                 config.SeriesAddEmbedColor = document.getElementById('discord-series-add-color-' + id).value;
                 config.SeriesDeleteEmbedColor = document.getElementById('discord-series-delete-color-' + id).value;
                 config.SeriesUpdateEmbedColor = document.getElementById('discord-series-update-color-' + id).value;
+                config.SeriesUpcomingEmbedColor = document.getElementById('discord-series-upcoming-color-' + id).value;
+                config.SeriesFeaturedEmbedColor = document.getElementById('discord-series-featured-color-' + id).value;
                 config.MoviesAddEmbedColor = document.getElementById('discord-movies-add-color-' + id).value;
                 config.MoviesDeleteEmbedColor = document.getElementById('discord-movies-delete-color-' + id).value;
                 config.MoviesUpdateEmbedColor = document.getElementById('discord-movies-update-color-' + id).value;
+                config.MoviesUpcomingEmbedColor = document.getElementById('discord-movies-upcoming-color-' + id).value;
+                config.MoviesFeaturedEmbedColor = document.getElementById('discord-movies-featured-color-' + id).value;
                 config.MaxItemsPerSection = Math.max(0, parseInt(document.getElementById('discord-max-items-' + id).value) || 0);
 
                 // Update Event Toggles
@@ -1071,17 +1079,21 @@
                     html += '    <div>';
                     html += '      <label class="inputLabel">Embed Colors:</label>';
                     html += '      <table class="color-table">';
-                    html += '        <tr><th>Series Add</th><th>Series Delete</th><th>Series Update</th></tr>';
+                    html += '        <tr><th>Series Add</th><th>Series Delete</th><th>Series Update</th><th>Series Upcoming</th><th>Series Featured</th></tr>';
                     html += '        <tr>';
                     html += '          <td><input id="discord-series-add-color-' + config.Id + '" type="color" value="' + (config.SeriesAddEmbedColor || '#00FF00') + '" onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"></td>';
                     html += '          <td><input id="discord-series-delete-color-' + config.Id + '" type="color" value="' + (config.SeriesDeleteEmbedColor || '#FF0000') + '" onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"></td>';
                     html += '          <td><input id="discord-series-update-color-' + config.Id + '" type="color" value="' + (config.SeriesUpdateEmbedColor || '#0000FF') + '" onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"></td>';
+                    html += '          <td><input id="discord-series-upcoming-color-' + config.Id + '" type="color" value="' + (config.SeriesUpcomingEmbedColor || '#FF8C00') + '" onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"></td>';
+                    html += '          <td><input id="discord-series-featured-color-' + config.Id + '" type="color" value="' + (config.SeriesFeaturedEmbedColor || '#FFC107') + '" onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"></td>';
                     html += '        </tr>';
-                    html += '        <tr><th>Movies Add</th><th>Movies Delete</th><th>Movies Update</th></tr>';
+                    html += '        <tr><th>Movies Add</th><th>Movies Delete</th><th>Movies Update</th><th>Movies Upcoming</th><th>Movies Featured</th></tr>';
                     html += '        <tr>';
                     html += '          <td><input id="discord-movies-add-color-' + config.Id + '" type="color" value="' + (config.MoviesAddEmbedColor || '#00FF00') + '" onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"></td>';
                     html += '          <td><input id="discord-movies-delete-color-' + config.Id + '" type="color" value="' + (config.MoviesDeleteEmbedColor || '#FF0000') + '" onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"></td>';
                     html += '          <td><input id="discord-movies-update-color-' + config.Id + '" type="color" value="' + (config.MoviesUpdateEmbedColor || '#0000FF') + '" onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"></td>';
+                    html += '          <td><input id="discord-movies-upcoming-color-' + config.Id + '" type="color" value="' + (config.MoviesUpcomingEmbedColor || '#FF8C00') + '" onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"></td>';
+                    html += '          <td><input id="discord-movies-featured-color-' + config.Id + '" type="color" value="' + (config.MoviesFeaturedEmbedColor || '#FFC107') + '" onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')"></td>';
                     html += '        </tr>';
                     html += '      </table>';
                     html += '    </div>';

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -863,7 +863,7 @@
                 return html;
             }
 
-            function getEventTogglesHtml(clientId, configType, added, updated, deleted, upcoming) {
+            function getEventTogglesHtml(clientId, configType, added, updated, deleted, upcoming, featured) {
                 var html = '<div>';
                 html += '  <label class="inputLabel">Events to Notify:</label>';
                 html += '  <table><tr>';
@@ -883,6 +883,10 @@
                 html += '    <td><div class="checkboxContainer"><label class="emby-checkbox-label">';
                 html += '    <input type="checkbox" is="emby-checkbox" id="' + configType + '-event-upcoming-' + clientId + '" ' + (upcoming === true ? 'checked' : '') + ' onchange="update' + (configType.charAt(0).toUpperCase() + configType.slice(1)) + 'ConfigFromUI(\'' + clientId + '\')"/>';
                 html += '    <span>Upcoming Item</span></label></div></td>';
+
+                html += '    <td><div class="checkboxContainer"><label class="emby-checkbox-label">';
+                html += '    <input type="checkbox" is="emby-checkbox" id="' + configType + '-event-featured-' + clientId + '" ' + (featured !== false ? 'checked' : '') + ' onchange="update' + (configType.charAt(0).toUpperCase() + configType.slice(1)) + 'ConfigFromUI(\'' + clientId + '\')"/>';
+                html += '    <span>Featured</span></label></div></td>';
 
                 html += '  </tr></table>';
                 html += '</div>';
@@ -927,6 +931,7 @@
                     NewsletterOnItemUpdatedEnabled: false,
                     NewsletterOnItemDeletedEnabled: true,
                     NewsletterOnUpcomingItemEnabled: false,
+                    NewsletterOnFeaturedEnabled: true,
                     MaxItemsPerSection: 0
                 };
                 discordConfigs.push(newConfig);
@@ -995,6 +1000,7 @@
                 config.NewsletterOnItemUpdatedEnabled = document.getElementById('discord-event-update-' + id).checked;
                 config.NewsletterOnItemDeletedEnabled = document.getElementById('discord-event-delete-' + id).checked;
                 config.NewsletterOnUpcomingItemEnabled = document.getElementById('discord-event-upcoming-' + id).checked;
+                config.NewsletterOnFeaturedEnabled = document.getElementById('discord-event-featured-' + id).checked;
 
                 // Update Library Selections
                 var seriesChecked = document.querySelectorAll('.discord-series-lib-' + id + ':checked');
@@ -1047,7 +1053,7 @@
                     html += '      <input id="discord-webhookname-' + config.Id + '" type="text" is="emby-input" value="' + (config.WebhookName || '') + '" onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')" />';
                     html += '    </div>';
                     html += getLibrarySelectionHtml(config.Id, 'discord', config.SelectedSeriesLibraries, config.SelectedMoviesLibraries);
-                    html += getEventTogglesHtml(config.Id, 'discord', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled);
+                    html += getEventTogglesHtml(config.Id, 'discord', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled, config.NewsletterOnFeaturedEnabled);
                     html += getMaxItemsHtml(config.Id, 'discord', config.MaxItemsPerSection);
                     html += '    <div>';
                     html += '      <label class="inputLabel">Message Fields:</label>';
@@ -1107,6 +1113,7 @@
                     NewsletterOnItemUpdatedEnabled: false,
                     NewsletterOnItemDeletedEnabled: true,
                     NewsletterOnUpcomingItemEnabled: false,
+                    NewsletterOnFeaturedEnabled: true,
                     MaxItemsPerSection: 0
                 };
                 telegramConfigs.push(newConfig);
@@ -1169,6 +1176,7 @@
                 config.NewsletterOnItemUpdatedEnabled = document.getElementById('telegram-event-update-' + id).checked;
                 config.NewsletterOnItemDeletedEnabled = document.getElementById('telegram-event-delete-' + id).checked;
                 config.NewsletterOnUpcomingItemEnabled = document.getElementById('telegram-event-upcoming-' + id).checked;
+                config.NewsletterOnFeaturedEnabled = document.getElementById('telegram-event-featured-' + id).checked;
 
                 // Update Library Selections
                 var seriesChecked = document.querySelectorAll('.telegram-series-lib-' + id + ':checked');
@@ -1221,7 +1229,7 @@
                     html += '      <div class="fieldDescription">Telegram chat ID or group ID to send messages to. Separate multiple IDs with commas.</div>';
                     html += '    </div>';
                     html += getLibrarySelectionHtml(config.Id, 'telegram', config.SelectedSeriesLibraries, config.SelectedMoviesLibraries);
-                    html += getEventTogglesHtml(config.Id, 'telegram', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled);
+                    html += getEventTogglesHtml(config.Id, 'telegram', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled, config.NewsletterOnFeaturedEnabled);
                     html += getMaxItemsHtml(config.Id, 'telegram', config.MaxItemsPerSection);
                     html += '    <div>';
                     html += '      <label class="inputLabel">Message Fields:</label>';
@@ -1267,6 +1275,7 @@
                     NewsletterOnItemUpdatedEnabled: false,
                     NewsletterOnItemDeletedEnabled: true,
                     NewsletterOnUpcomingItemEnabled: false,
+                    NewsletterOnFeaturedEnabled: true,
                     EnableSsl: true,
                     UseAuthentication: true,
                     MaxItemsPerSection: 0
@@ -1336,6 +1345,7 @@
                 config.NewsletterOnItemUpdatedEnabled = document.getElementById('email-event-update-' + id).checked;
                 config.NewsletterOnItemDeletedEnabled = document.getElementById('email-event-delete-' + id).checked;
                 config.NewsletterOnUpcomingItemEnabled = document.getElementById('email-event-upcoming-' + id).checked;
+                config.NewsletterOnFeaturedEnabled = document.getElementById('email-event-featured-' + id).checked;
 
                 // Update Library Selections
                 var seriesChecked = document.querySelectorAll('.email-series-lib-' + id + ':checked');
@@ -1432,7 +1442,7 @@
                     html += '      <input id="email-subject-' + config.Id + '" type="text" is="emby-input" value="' + (config.Subject || '') + '" onchange="updateEmailConfigFromUI(\'' + config.Id + '\')" />';
                     html += '    </div>';
                     html += getLibrarySelectionHtml(config.Id, 'email', config.SelectedSeriesLibraries, config.SelectedMoviesLibraries);
-                    html += getEventTogglesHtml(config.Id, 'email', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled);
+                    html += getEventTogglesHtml(config.Id, 'email', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled, config.NewsletterOnFeaturedEnabled);
                     html += getMaxItemsHtml(config.Id, 'email', config.MaxItemsPerSection);
                     html += '    <div class="inputContainer">';
                     html += '      <label class="selectLabel" for="email-category-' + config.Id + '">Template Category:</label>';
@@ -1484,6 +1494,7 @@
                     NewsletterOnItemUpdatedEnabled: false,
                     NewsletterOnItemDeletedEnabled: true,
                     NewsletterOnUpcomingItemEnabled: false,
+                    NewsletterOnFeaturedEnabled: true,
                     MaxItemsPerSection: 0
                 };
                 matrixConfigs.push(newConfig);
@@ -1541,6 +1552,7 @@
                 config.NewsletterOnItemUpdatedEnabled = document.getElementById('matrix-event-update-' + id).checked;
                 config.NewsletterOnItemDeletedEnabled = document.getElementById('matrix-event-delete-' + id).checked;
                 config.NewsletterOnUpcomingItemEnabled = document.getElementById('matrix-event-upcoming-' + id).checked;
+                config.NewsletterOnFeaturedEnabled = document.getElementById('matrix-event-featured-' + id).checked;
 
                 var seriesChecked = document.querySelectorAll('.matrix-series-lib-' + id + ':checked');
                 config.SelectedSeriesLibraries = Array.from(seriesChecked).map(function (cb) { return cb.getAttribute('data-lib-id'); });
@@ -1596,7 +1608,7 @@
                     html += '      <div class="fieldDescription">The internal room ID (e.g., !yourRoomId:example.com). Separate multiple with commas.</div>';
                     html += '    </div>';
                     html += getLibrarySelectionHtml(config.Id, 'matrix', config.SelectedSeriesLibraries, config.SelectedMoviesLibraries);
-                    html += getEventTogglesHtml(config.Id, 'matrix', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled);
+                    html += getEventTogglesHtml(config.Id, 'matrix', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled, config.NewsletterOnFeaturedEnabled);
                     html += getMaxItemsHtml(config.Id, 'matrix', config.MaxItemsPerSection);
                     html += '    <div class="inputContainer">';
                     html += '      <label class="selectLabel" for="matrix-category-' + config.Id + '">Template Category:</label>';

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -17,6 +17,7 @@
                         <button type="button" class="tab-link active"
                             onclick="openTab(event, 'General')">General</button>
                         <button type="button" class="tab-link" onclick="openTab(event, 'Preview')">Preview</button>
+                        <button type="button" class="tab-link" onclick="openTab(event, 'Featured')">Featured</button>
                         <button type="button" class="tab-link" onclick="openTab(event, 'Email')">Email</button>
                         <button type="button" class="tab-link" onclick="openTab(event, 'Discord')">Discord</button>
                         <button type="button" class="tab-link" onclick="openTab(event, 'Telegram')">Telegram</button>
@@ -154,6 +155,34 @@
                         <div id="PreviewSummary" class="fieldDescription" style="margin-bottom: 10px;"></div>
                         <div id="PreviewList" class="config-list">
                             <p class="no-configs-text">Loading&hellip;</p>
+                        </div>
+                    </div>
+
+                    <!-- Featured Tab -->
+                    <div id="Featured" class="tab-content">
+                        <div class="config-header">
+                            <h3>Featured</h3>
+                        </div>
+                        <div class="fieldDescription" style="margin-bottom: 15px;">
+                            Pin hand-picked titles to the top of the next newsletter. Anything in your
+                            library can be featured, whether or not it was added recently.
+                            <br>
+                            <b>The list is cleared once a newsletter is sent</b>, so each issue is curated
+                            deliberately rather than repeating last week's pick.
+                        </div>
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="FeaturedEmoji">Featured Emoji:</label>
+                            <input id="FeaturedEmoji" name="FeaturedEmoji" type="text" is="emby-input" />
+                            <div class="fieldDescription">Shown beside the Featured heading. Default: &#11088;</div>
+                        </div>
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="FeaturedSearch">Add a title:</label>
+                            <input id="FeaturedSearch" type="text" is="emby-input" placeholder="Search your library&hellip;"
+                                oninput="searchFeatured(this.value)" autocomplete="off" />
+                        </div>
+                        <div id="FeaturedResults" class="config-list"></div>
+                        <div id="FeaturedList" class="config-list">
+                            <p class="no-configs-text">Nothing featured for the next newsletter.</p>
                         </div>
                     </div>
 
@@ -466,6 +495,18 @@
             }
 
             .preview-title {
+            /* Featured */
+            .featured-row {
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                padding: 8px 12px;
+                border: 1px solid #444;
+                border-radius: 4px;
+                margin-bottom: 6px;
+            }
+
+            .featured-row .featured-name {
                 flex: 1;
                 min-width: 0;
                 overflow: hidden;
@@ -475,6 +516,8 @@
 
             .preview-meta {
                 opacity: 0.7;
+            .featured-row .featured-meta {
+                opacity: 0.65;
                 font-size: 0.85em;
                 white-space: nowrap;
             }
@@ -538,6 +581,13 @@
             .preview-excluded .preview-episode-label {
                 opacity: 0.45;
                 text-decoration: line-through;
+            #FeaturedResults .featured-row {
+                cursor: pointer;
+                border-style: dashed;
+            }
+
+            #FeaturedResults .featured-row:hover {
+                background: rgba(255, 255, 255, 0.06);
             }
         </style>
         <script type="text/javascript">
@@ -1565,6 +1615,135 @@
 
             // ===================== LIBRARY FUNCTIONS =====================
 
+            function escapeHtml(value) {
+                return String(value === null || value === undefined ? '' : value)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#39;');
+            }
+
+            // ===================== FEATURED =====================
+
+            var featuredItems = [];   // [{ Id, Name, Type, ProductionYear }]
+            var featuredSearchTimer = null;
+
+            function renderFeatured() {
+                var container = document.getElementById('FeaturedList');
+                if (!container) return;
+
+                if (!featuredItems.length) {
+                    container.innerHTML = '<p class="no-configs-text">Nothing featured for the next newsletter.</p>';
+                    return;
+                }
+
+                var html = '';
+                featuredItems.forEach(function (item) {
+                    html += '<div class="featured-row">';
+                    html += '  <span class="featured-name">' + escapeHtml(item.Name) + '</span>';
+                    html += '  <span class="featured-meta">' + escapeHtml(item.Type === 'Movie' ? 'Movie' : 'Series')
+                        + (item.ProductionYear ? ' &middot; ' + escapeHtml(item.ProductionYear) : '') + '</span>';
+                    html += '  <button type="button" class="config-action-btn delete-btn"'
+                        + ' onclick="removeFeatured(\'' + escapeHtml(item.Id) + '\')">Remove</button>';
+                    html += '</div>';
+                });
+                container.innerHTML = html;
+            }
+
+            function searchFeatured(term) {
+                if (featuredSearchTimer) clearTimeout(featuredSearchTimer);
+
+                var results = document.getElementById('FeaturedResults');
+                if (!results) return;
+
+                if (!term || term.trim().length < 2) {
+                    results.innerHTML = '';
+                    return;
+                }
+
+                featuredSearchTimer = setTimeout(function () {
+                    var url = ApiClient.getUrl('Items', {
+                        searchTerm: term.trim(),
+                        IncludeItemTypes: 'Movie,Series',
+                        Recursive: true,
+                        Limit: 8,
+                        userId: ApiClient.getCurrentUserId(),
+                        Fields: 'ProductionYear'
+                    });
+
+                    ApiClient.getJSON(url).then(function (result) {
+                        var items = (result && result.Items) || [];
+                        if (!items.length) {
+                            results.innerHTML = '<p class="no-configs-text">No matches.</p>';
+                            return;
+                        }
+
+                        var html = '';
+                        items.forEach(function (item) {
+                            if (featuredItems.some(function (f) { return f.Id === item.Id; })) return;
+                            html += '<div class="featured-row" onclick="addFeatured(\'' + escapeHtml(item.Id) + '\')">';
+                            html += '  <span class="featured-name">' + escapeHtml(item.Name) + '</span>';
+                            html += '  <span class="featured-meta">' + escapeHtml(item.Type === 'Movie' ? 'Movie' : 'Series')
+                                + (item.ProductionYear ? ' &middot; ' + escapeHtml(item.ProductionYear) : '') + '</span>';
+                            html += '</div>';
+                        });
+                        results.innerHTML = html || '<p class="no-configs-text">Already featured.</p>';
+                        window._featuredSearchCache = items;
+                    }).catch(function (error) {
+                        console.error('Featured search failed:', error);
+                        results.innerHTML = '<p class="no-configs-text">Search failed. Check the Jellyfin logs.</p>';
+                    });
+                }, 300);
+            }
+
+            function addFeatured(id) {
+                var found = (window._featuredSearchCache || []).filter(function (i) { return i.Id === id; })[0];
+                if (!found) return;
+
+                if (!featuredItems.some(function (f) { return f.Id === id; })) {
+                    featuredItems.push(found);
+                    renderFeatured();
+                }
+
+                var search = document.getElementById('FeaturedSearch');
+                if (search) search.value = '';
+                var results = document.getElementById('FeaturedResults');
+                if (results) results.innerHTML = '';
+            }
+
+            function removeFeatured(id) {
+                featuredItems = featuredItems.filter(function (f) { return f.Id !== id; });
+                renderFeatured();
+            }
+
+            function loadFeatured(ids) {
+                featuredItems = [];
+                if (!ids || !ids.length) {
+                    renderFeatured();
+                    return;
+                }
+
+                // Config stores IDs only; resolve them to names for display.
+                var url = ApiClient.getUrl('Items', {
+                    ids: ids.join(','),
+                    Recursive: true,
+                    userId: ApiClient.getCurrentUserId(),
+                    Fields: 'ProductionYear'
+                });
+
+                ApiClient.getJSON(url).then(function (result) {
+                    var byId = {};
+                    ((result && result.Items) || []).forEach(function (i) { byId[i.Id] = i; });
+                    // Preserve the configured order, and drop anything no longer in the library.
+                    ids.forEach(function (id) { if (byId[id]) featuredItems.push(byId[id]); });
+                    renderFeatured();
+                }).catch(function (error) {
+                    console.error('Could not resolve featured items:', error);
+                    renderFeatured();
+                });
+            }
+
             function loadLibraries() {
                 // Return a promise to ensure libraries are loaded before rendering client configs
                 return ApiClient.getJSON(ApiClient.getUrl('Library/MediaFolders')).then(function (result) {
@@ -1610,6 +1789,9 @@
                     config.EmailConfigurations = emailConfigs;
                     config.RadarrConfigurations = radarrConfigs;
                     config.SonarrConfigurations = sonarrConfigs;
+                    config.FeaturedItemIds = featuredItems.map(function (i) { return i.Id; });
+                    var featuredEmojiEl = document.querySelector('#FeaturedEmoji');
+                    if (featuredEmojiEl) config.FeaturedEmoji = (featuredEmojiEl.value || '').trim() || '\u2B50';
 
                     ApiClient.updatePluginConfiguration(NewsletterConfig.pluginUniqueId, config).then(function (result) {
                         Dashboard.processPluginConfigurationUpdateResult(result);
@@ -1622,15 +1804,6 @@
 
             var previewData = null;
             var previewExpanded = {};
-
-            function escapeHtml(value) {
-                return String(value === null || value === undefined ? '' : value)
-                    .replace(/&/g, '&amp;')
-                    .replace(/</g, '&lt;')
-                    .replace(/>/g, '&gt;')
-                    .replace(/"/g, '&quot;')
-                    .replace(/'/g, '&#39;');
-            }
 
             function previewGroupKey(group) {
                 return group.Title + ' ' + group.EventType;
@@ -1840,6 +2013,9 @@
                     var hostingEl = document.querySelector('#HostingSelector');
                     if (hostingEl && config.PosterType) hostingEl.value = config.PosterType;
 
+                    var featuredEmojiEl = document.querySelector('#FeaturedEmoji');
+                    if (featuredEmojiEl) featuredEmojiEl.value = config.FeaturedEmoji || '\u2B50';
+
                     var ratingEl = document.querySelector('#CommunityRatingDecimalPlaces');
                     if (ratingEl) ratingEl.value = config.CommunityRatingDecimalPlaces !== undefined ? config.CommunityRatingDecimalPlaces : 1;
 
@@ -1866,6 +2042,7 @@
                         renderRadarrConfigs();
                         renderSonarrConfigs();
                         loadPreview();
+                        loadFeatured(config.FeaturedItemIds || []);
                         Dashboard.hideLoadingMsg();
                     });
                 });

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -495,6 +495,13 @@
             }
 
             .preview-title {
+                flex: 1;
+                min-width: 0;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
             /* Featured */
             .featured-row {
                 display: flex;
@@ -514,10 +521,14 @@
                 white-space: nowrap;
             }
 
-            .preview-meta {
-                opacity: 0.7;
             .featured-row .featured-meta {
                 opacity: 0.65;
+                font-size: 0.85em;
+                white-space: nowrap;
+            }
+
+            .preview-meta {
+                opacity: 0.7;
                 font-size: 0.85em;
                 white-space: nowrap;
             }
@@ -581,6 +592,8 @@
             .preview-excluded .preview-episode-label {
                 opacity: 0.45;
                 text-decoration: line-through;
+            }
+
             #FeaturedResults .featured-row {
                 cursor: pointer;
                 border-style: dashed;

--- a/Jellyfin.Plugin.Newsletters/Featured/FeaturedItems.cs
+++ b/Jellyfin.Plugin.Newsletters/Featured/FeaturedItems.cs
@@ -133,14 +133,4 @@ public static class FeaturedItems
 
         return string.Empty;
     }
-
-    /// <summary>
-    /// Gets a value indicating whether the item is a type that can be featured.
-    /// </summary>
-    /// <param name="item">The library item.</param>
-    /// <returns>True for movies and series.</returns>
-    public static bool IsFeaturable(BaseItem item)
-    {
-        return item is Movie || item is Series;
-    }
 }

--- a/Jellyfin.Plugin.Newsletters/Featured/FeaturedItems.cs
+++ b/Jellyfin.Plugin.Newsletters/Featured/FeaturedItems.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -27,6 +28,12 @@ public static class FeaturedItems
     /// The event type featured entries carry through the newsletter pipeline.
     /// </summary>
     public const string EventType = "featured";
+
+    // Resolving a poster costs a TMDB round trip, and every client config builds its own
+    // ClientBuilder - so without this the same pick is fetched once per configured client.
+    // Keyed by item ID and dropped when the featured list is consumed, so an entry lives
+    // for exactly one issue.
+    private static readonly ConcurrentDictionary<string, string> PosterUrlCache = new();
 
     // Same provider-to-TMDB key mapping the scanner uses when it builds an entry.
     private static readonly Dictionary<string, string> AllowedExternalIds = new()
@@ -133,7 +140,34 @@ public static class FeaturedItems
         return entry;
     }
 
+    /// <summary>
+    /// Drops the poster URLs resolved for the current featured list.
+    /// Call this when the list itself is cleared, so the next issue resolves afresh.
+    /// </summary>
+    public static void ClearPosterCache()
+    {
+        PosterUrlCache.Clear();
+    }
+
     private static string ResolveImageUrl(JsonFileObj entry, Logger logger, SQLiteDatabase db, PosterImageHandler imageHandler, string? hostname)
+    {
+        if (!string.IsNullOrEmpty(entry.ItemID) && PosterUrlCache.TryGetValue(entry.ItemID, out string? memoized))
+        {
+            logger.Debug($"Reusing the poster URL already resolved this cycle for '{entry.Title}'");
+            return memoized;
+        }
+
+        string resolved = ResolveImageUrlUncached(entry, logger, db, imageHandler, hostname);
+
+        if (!string.IsNullOrEmpty(entry.ItemID))
+        {
+            PosterUrlCache[entry.ItemID] = resolved;
+        }
+
+        return resolved;
+    }
+
+    private static string ResolveImageUrlUncached(JsonFileObj entry, Logger logger, SQLiteDatabase db, PosterImageHandler imageHandler, string? hostname)
     {
         // Prefer a URL an earlier scan already resolved for this title, exactly as the scanner does.
         try

--- a/Jellyfin.Plugin.Newsletters/Featured/FeaturedItems.cs
+++ b/Jellyfin.Plugin.Newsletters/Featured/FeaturedItems.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using Jellyfin.Plugin.Newsletters.Shared.Entities;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.Newsletters.Featured;
+
+/// <summary>
+/// Resolves the admin's pinned library items into newsletter entries.
+/// </summary>
+/// <remarks>
+/// Featured items are read live from the library at send time rather than from the queue table,
+/// the same way upcoming items are, so anything in the library can be featured regardless of when
+/// it was added and nothing about the queue changes.
+/// </remarks>
+public static class FeaturedItems
+{
+    /// <summary>
+    /// The event type featured entries carry through the newsletter pipeline.
+    /// </summary>
+    public const string EventType = "featured";
+
+    /// <summary>
+    /// The single section heading featured entries are grouped under, spanning all libraries.
+    /// </summary>
+    public const string SectionName = "Featured";
+
+    /// <summary>
+    /// Builds newsletter entries for the given library item IDs.
+    /// </summary>
+    /// <param name="libraryManager">The Jellyfin library manager.</param>
+    /// <param name="logger">The logger used to report items that cannot be resolved.</param>
+    /// <param name="hostname">The configured server URL, used to build poster URLs.</param>
+    /// <param name="itemIds">The pinned Jellyfin item IDs, in the order they should appear.</param>
+    /// <returns>The resolved entries. IDs that no longer exist are skipped.</returns>
+    public static Collection<JsonFileObj> Build(
+        ILibraryManager libraryManager,
+        Logger logger,
+        string? hostname,
+        IEnumerable<string>? itemIds)
+    {
+        var featured = new Collection<JsonFileObj>();
+
+        foreach (var rawId in itemIds ?? Enumerable.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(rawId) || !Guid.TryParse(rawId, out var guid))
+            {
+                continue;
+            }
+
+            try
+            {
+                var item = libraryManager.GetItemById(guid);
+                if (item is null)
+                {
+                    logger.Warn($"Featured item {rawId} no longer exists in the library - skipping");
+                    continue;
+                }
+
+                featured.Add(ToEntry(item, libraryManager, hostname));
+            }
+            catch (Exception ex)
+            {
+                logger.Error($"Could not resolve featured item {rawId}: {ex.Message}");
+            }
+        }
+
+        return featured;
+    }
+
+    private static JsonFileObj ToEntry(BaseItem item, ILibraryManager libraryManager, string? hostname)
+    {
+        var entry = new JsonFileObj
+        {
+            Title = item.Name ?? string.Empty,
+            SeriesOverview = item.Overview ?? string.Empty,
+            ItemID = item.Id.ToString("N", CultureInfo.InvariantCulture),
+            Type = item is Movie ? "Movie" : "Series",
+            OfficialRating = item.OfficialRating ?? string.Empty,
+            CommunityRating = item.CommunityRating ?? 0.0f,
+            PosterPath = item.PrimaryImagePath ?? string.Empty,
+            EventType = EventType,
+            Genres = item.Genres is null ? string.Empty : string.Join(", ", item.Genres),
+            LibraryId = ResolveLibraryId(item, libraryManager),
+            // A featured entry is a whole title, not an episode. -1 keeps it out of the
+            // season/episode line the way the scanner marks items with no episode number.
+            Season = -1,
+            Episode = -1
+        };
+
+        if (item.ProductionYear.HasValue)
+        {
+            entry.PremiereYear = item.ProductionYear.Value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (item.RunTimeTicks.HasValue)
+        {
+            entry.RunTime = (int)TimeSpan.FromTicks(item.RunTimeTicks.Value).TotalMinutes;
+        }
+
+        // Unlike scanned items there is no cached TMDB URL to reuse, so point at the server's
+        // own image endpoint. Attachment mode uses PosterPath above and ignores this.
+        if (!string.IsNullOrWhiteSpace(hostname))
+        {
+            entry.ImageURL = $"{hostname.TrimEnd('/')}/Items/{entry.ItemID}/Images/Primary";
+        }
+
+        return entry;
+    }
+
+    private static string ResolveLibraryId(BaseItem item, ILibraryManager libraryManager)
+    {
+        // The real library ID is kept so per-client library filtering still applies to featured
+        // items; the single-section grouping is done by event type instead.
+        try
+        {
+            var folder = libraryManager.GetCollectionFolders(item).FirstOrDefault();
+            if (folder is not null)
+            {
+                return folder.Id.ToString("N", CultureInfo.InvariantCulture);
+            }
+        }
+        catch (Exception)
+        {
+            // fall through - an unresolved library just means no library filtering
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the item is a type that can be featured.
+    /// </summary>
+    /// <param name="item">The library item.</param>
+    /// <returns>True for movies and series.</returns>
+    public static bool IsFeaturable(BaseItem item)
+    {
+        return item is Movie || item is Series;
+    }
+}

--- a/Jellyfin.Plugin.Newsletters/Featured/FeaturedItems.cs
+++ b/Jellyfin.Plugin.Newsletters/Featured/FeaturedItems.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
+using Jellyfin.Plugin.Newsletters.Scanner;
+using Jellyfin.Plugin.Newsletters.Shared.Database;
 using Jellyfin.Plugin.Newsletters.Shared.Entities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
@@ -26,6 +28,14 @@ public static class FeaturedItems
     /// </summary>
     public const string EventType = "featured";
 
+    // Same provider-to-TMDB key mapping the scanner uses when it builds an entry.
+    private static readonly Dictionary<string, string> AllowedExternalIds = new()
+    {
+        { "Imdb", "imdb_id" },
+        { "Tmdb", "tmdb" },
+        { "Tvdb", "tvdb_id" },
+    };
+
     /// <summary>
     /// The single section heading featured entries are grouped under, spanning all libraries.
     /// </summary>
@@ -36,12 +46,16 @@ public static class FeaturedItems
     /// </summary>
     /// <param name="libraryManager">The Jellyfin library manager.</param>
     /// <param name="logger">The logger used to report items that cannot be resolved.</param>
-    /// <param name="hostname">The configured server URL, used to build poster URLs.</param>
+    /// <param name="db">The database searched for an already known poster URL.</param>
+    /// <param name="imageHandler">The handler used to look up and fetch poster URLs.</param>
+    /// <param name="hostname">The configured server URL, used as the poster URL of last resort.</param>
     /// <param name="itemIds">The pinned Jellyfin item IDs, in the order they should appear.</param>
     /// <returns>The resolved entries. IDs that no longer exist are skipped.</returns>
     public static Collection<JsonFileObj> Build(
         ILibraryManager libraryManager,
         Logger logger,
+        SQLiteDatabase db,
+        PosterImageHandler imageHandler,
         string? hostname,
         IEnumerable<string>? itemIds)
     {
@@ -63,7 +77,7 @@ public static class FeaturedItems
                     continue;
                 }
 
-                featured.Add(ToEntry(item, libraryManager, hostname));
+                featured.Add(ToEntry(item, libraryManager, logger, db, imageHandler, hostname));
             }
             catch (Exception ex)
             {
@@ -74,7 +88,7 @@ public static class FeaturedItems
         return featured;
     }
 
-    private static JsonFileObj ToEntry(BaseItem item, ILibraryManager libraryManager, string? hostname)
+    private static JsonFileObj ToEntry(BaseItem item, ILibraryManager libraryManager, Logger logger, SQLiteDatabase db, PosterImageHandler imageHandler, string? hostname)
     {
         var entry = new JsonFileObj
         {
@@ -104,14 +118,62 @@ public static class FeaturedItems
             entry.RunTime = (int)TimeSpan.FromTicks(item.RunTimeTicks.Value).TotalMinutes;
         }
 
-        // Unlike scanned items there is no cached TMDB URL to reuse, so point at the server's
-        // own image endpoint. Attachment mode uses PosterPath above and ignores this.
-        if (!string.IsNullOrWhiteSpace(hostname))
+        // The scanner keys its TMDB lookups off these, so carry them over and the same
+        // resolution works for a featured pick. Attachment mode uses PosterPath and ignores it.
+        foreach (var kvp in item.ProviderIds)
         {
-            entry.ImageURL = $"{hostname.TrimEnd('/')}/Items/{entry.ItemID}/Images/Primary";
+            if (AllowedExternalIds.TryGetValue(kvp.Key, out var mappedKey))
+            {
+                entry.ExternalIds[mappedKey] = kvp.Value;
+            }
         }
 
+        entry.ImageURL = ResolveImageUrl(entry, logger, db, imageHandler, hostname);
+
         return entry;
+    }
+
+    private static string ResolveImageUrl(JsonFileObj entry, Logger logger, SQLiteDatabase db, PosterImageHandler imageHandler, string? hostname)
+    {
+        // Prefer a URL an earlier scan already resolved for this title, exactly as the scanner does.
+        try
+        {
+            db.CreateConnection();
+            string cached = imageHandler.FindCachedImageUrl(db, entry.Title);
+            if (!string.IsNullOrEmpty(cached))
+            {
+                return cached;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.Warn($"Could not check for a cached image URL for '{entry.Title}': {ex.Message}");
+        }
+        finally
+        {
+            db.CloseConnection();
+        }
+
+        // Nothing cached - ask TMDB the same way a scan would.
+        try
+        {
+            string fetched = imageHandler.FetchImagePoster(entry);
+            if (!string.IsNullOrEmpty(fetched) && fetched != "429" && fetched != "ERR")
+            {
+                return fetched;
+            }
+
+            logger.Warn($"Could not obtain a poster URL for featured item '{entry.Title}'");
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"Poster lookup failed for featured item '{entry.Title}': {ex.Message}");
+        }
+
+        // Last resort: the server's own image endpoint, which needs a reachable hostname.
+        return string.IsNullOrWhiteSpace(hostname)
+            ? string.Empty
+            : $"{hostname.TrimEnd('/')}/Items/{entry.ItemID}/Images/Primary";
     }
 
     private static string ResolveLibraryId(BaseItem item, ILibraryManager libraryManager)

--- a/Jellyfin.Plugin.Newsletters/Scanner/PosterImageHandler.cs
+++ b/Jellyfin.Plugin.Newsletters/Scanner/PosterImageHandler.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using Jellyfin.Plugin.Newsletters.Shared.Database;
 using Jellyfin.Plugin.Newsletters.Shared.Entities;
 using Newtonsoft.Json.Linq;
 
@@ -19,6 +20,39 @@ public class PosterImageHandler(Logger loggerInstance)
     private static readonly object RateLimitLock = new();
     private static readonly TimeSpan MinInterval = TimeSpan.FromMilliseconds(25);
     private static DateTime lastRequestTime = DateTime.MinValue;
+
+    /// <summary>
+    /// Looks for an image URL already stored against this title in the newsletter tables.
+    /// Saves a round trip to TMDB for anything that has been through a scan before.
+    /// </summary>
+    /// <param name="db">The database to search. The caller owns the connection.</param>
+    /// <param name="title">The title to look for.</param>
+    /// <returns>The stored URL, or an empty string when nothing is cached for the title.</returns>
+    public string FindCachedImageUrl(SQLiteDatabase db, string title)
+    {
+        string[] tables = { "CurrRunData", "CurrNewsletterData", "ArchiveData" };
+
+        foreach (string table in tables)
+        {
+            foreach (var row in db.Query($"SELECT * FROM {table};"))
+            {
+                if (row is null)
+                {
+                    continue;
+                }
+
+                JsonFileObj fileObj = JsonFileObj.ConvertToObj(row);
+                if ((fileObj is not null) && (fileObj.Title == title) && (fileObj.ImageURL.Length > 0))
+                {
+                    logger.Debug($"Found cached image URL for {title} in {table} :: {fileObj.ImageURL}");
+                    return fileObj.ImageURL;
+                }
+            }
+        }
+
+        logger.Debug($"No cached image URL for {title}");
+        return string.Empty;
+    }
 
     /// <summary>
     /// Fetches the poster image URL for the given item using external IDs (e.g., TMDB).

--- a/Jellyfin.Plugin.Newsletters/Scanner/Scraper.cs
+++ b/Jellyfin.Plugin.Newsletters/Scanner/Scraper.cs
@@ -633,55 +633,14 @@ public class Scraper
 
     private string SetImageURL(JsonFileObj currObj)
     {
-        JsonFileObj fileObj;
-        string currTitle = currObj.Title.Replace("'", "''", StringComparison.Ordinal);
-
-        // check if URL for series already exists CurrRunData table
-        foreach (var row in db.Query("SELECT * FROM CurrRunData;"))
+        string cached = imageHandler.FindCachedImageUrl(db, currObj.Title);
+        if (!string.IsNullOrEmpty(cached))
         {
-            if (row is not null)
-            {
-                fileObj = JsonFileObj.ConvertToObj(row);
-                if ((fileObj is not null) && (fileObj.Title == currTitle) && (fileObj.ImageURL.Length > 0))
-                {
-                    logger.Debug("Found Current Scan of URL for " + currTitle + " :: " + fileObj.ImageURL);
-                    return fileObj.ImageURL;
-                }
-            }
-        }
-
-        // check if URL for series already exists CurrNewsletterData table
-        logger.Debug("Checking if exists in CurrNewsletterData");
-        foreach (var row in db.Query("SELECT * FROM CurrNewsletterData;"))
-        {
-            if (row is not null)
-            {
-                fileObj = JsonFileObj.ConvertToObj(row);
-                if ((fileObj is not null) && (fileObj.Title == currTitle) && (fileObj.ImageURL.Length > 0))
-                {
-                    logger.Debug("Found Current Scan of URL for " + currTitle + " :: " + fileObj.ImageURL);
-                    return fileObj.ImageURL;
-                }
-            }
-        }
-
-        // check if URL for series already exists ArchiveData table
-        foreach (var row in db.Query("SELECT * FROM ArchiveData;"))
-        {
-            if (row is not null)
-            {
-                fileObj = JsonFileObj.ConvertToObj(row);
-                if ((fileObj is not null) && (fileObj.Title == currTitle) && (fileObj.ImageURL.Length > 0))
-                {
-                    logger.Debug("Found Current Scan of URL for " + currTitle + " :: " + fileObj.ImageURL);
-                    return fileObj.ImageURL;
-                }
-            }
+            return cached;
         }
 
         logger.Debug("Grabbing poster...");
         logger.Debug(currObj.ItemID);
-        // return string.Empty;
         return imageHandler.FetchImagePoster(currObj);
     }
 

--- a/Jellyfin.Plugin.Newsletters/Templates/Classic/template_header.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Classic/template_header.html
@@ -2,7 +2,7 @@
     <tr>
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
-                style='color: #b07dd6; margin: 0; font-size: 1.8em; border-bottom: 2px solid #b07dd6; padding-bottom: 10px; display: flex;'>
+                style='color: #E8C05A; margin: 0; font-size: 1.8em; border-bottom: 2px solid #E8C05A; padding-bottom: 10px; display: flex;'>
                 <span style='margin-right: 4px;'>{FeaturedEmoji}</span> Featured
             </h2>
         </td>

--- a/Jellyfin.Plugin.Newsletters/Templates/Classic/template_header.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Classic/template_header.html
@@ -1,3 +1,14 @@
+<template id="header-featured">
+    <tr>
+        <td colspan='2' style='padding: 20px 10px 10px 10px;'>
+            <h2
+                style='color: #b07dd6; margin: 0; font-size: 1.8em; border-bottom: 2px solid #b07dd6; padding-bottom: 10px; display: flex;'>
+                <span style='margin-right: 4px;'>{FeaturedEmoji}</span> Featured
+            </h2>
+        </td>
+    </tr>
+</template>
+
 <template id="header-add">
     <tr>
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>

--- a/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_header.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_header.html
@@ -1,3 +1,7 @@
+<template id="header-featured">
+<h2><font data-mx-color='#8E24AA'>{FeaturedEmoji} Featured</font></h2><hr/>
+</template>
+
 <template id="header-add">
 <h2><font data-mx-color='#4CAF50'>🎬 Added to {LibraryName}</font></h2><hr/>
 </template>

--- a/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_header.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_header.html
@@ -1,5 +1,5 @@
 <template id="header-featured">
-<h2><font data-mx-color='#8E24AA'>{FeaturedEmoji} Featured</font></h2><hr/>
+<h2><font data-mx-color='#FFC107'>{FeaturedEmoji} Featured</font></h2><hr/>
 </template>
 
 <template id="header-add">

--- a/Jellyfin.Plugin.Newsletters/Templates/Modern/template_header.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Modern/template_header.html
@@ -2,7 +2,7 @@
     <tr>
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>
             <h2
-                style='color: #8E24AA; margin: 0; font-size: 1.8em; border-bottom: 2px solid #8E24AA; padding-bottom: 10px; display: flex;'>
+                style='color: #FFC107; margin: 0; font-size: 1.8em; border-bottom: 2px solid #FFC107; padding-bottom: 10px; display: flex;'>
                 <span style='margin-right: 4px;'>{FeaturedEmoji}</span> Featured
             </h2>
         </td>

--- a/Jellyfin.Plugin.Newsletters/Templates/Modern/template_header.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Modern/template_header.html
@@ -1,3 +1,14 @@
+<template id="header-featured">
+    <tr>
+        <td colspan='2' style='padding: 20px 10px 10px 10px;'>
+            <h2
+                style='color: #8E24AA; margin: 0; font-size: 1.8em; border-bottom: 2px solid #8E24AA; padding-bottom: 10px; display: flex;'>
+                <span style='margin-right: 4px;'>{FeaturedEmoji}</span> Featured
+            </h2>
+        </td>
+    </tr>
+</template>
+
 <template id="header-add">
     <tr>
         <td colspan='2' style='padding: 20px 10px 10px 10px;'>


### PR DESCRIPTION
Closes #112.

## What this adds

A **Featured** section pinned to the top of the newsletter, containing titles the admin hand-picks from their own library.

```
⭐ Featured
   the one or two things you actually want people to watch

🎬 Added to Movies
📺 Added to Shows
🔄 Updated in ...
```

The newsletter is otherwise entirely automatic — it reports whatever the scanner happened to pick up. There was no way to say "this is the thing worth watching this week", and nothing already in the library could be highlighted at all.

## How it works

Featured items reuse the shape the **Upcoming** integration established: resolved live at send time rather than pulled from the queue, merged into the sorted list with their own event type, rendered through their own header template, and gated by a per-client toggle.

- `PluginConfiguration.FeaturedItemIds` (library item IDs, order preserved) and `FeaturedEmoji` (default ⭐).
- `Featured/FeaturedItems` resolves those IDs through `ILibraryManager` into the plugin's existing item model, so featured entries render with the same poster, overview, year, rating and runtime as every other entry. IDs that no longer exist are skipped with a warning rather than failing the send.
- Event type `featured`, ordered ahead of `add`, and grouped into **one section spanning libraries** — splitting a hand-picked list of three titles across three library headings would defeat the point.
- `header-featured` added to the bundled **Classic, Modern and Matrix** templates.
- Per-client `NewsletterOnFeaturedEnabled`, matching the existing add/update/delete/upcoming switches.
- A picker in the settings page: search the library, click to add, remove to drop.

**The list is cleared when a newsletter sends**, in the same place the queue is archived. Persisting it would mean an admin who forgets leaves the same title leading every newsletter indefinitely — silent, recurring, and visible to every recipient. Re-picking each week is the self-correcting failure.

Nothing about the queue changes: featured items never enter `CurrNewsletterData` and are never archived.

## Two details worth flagging

- **Featured entries keep their real `LibraryId`.** Grouping them under a synthetic library ID would have made `ShouldIncludeItem`'s library-selection check silently drop every featured item, since that ID matches no selected library. The single-section grouping is done by event type instead.
- **`GetEventBadge` and `GetEventDescriptionPrefixBase` gained a `featured` case.** Both fall through to a `NEW` / 🎬 default for unknown event types, so without this a featured entry would have been labelled "Added to Featured" on Discord and Telegram.

## Testing

Built against net9.0 and exercised on a live Jellyfin 10.11.11 server:

- Picker round-trips: search, add, save, reload — selections persist and are re-resolved to names from the stored IDs.
- Featured items render above the added/updated/removed sections, in one section, with the ⭐ heading.
- A newsletter containing *only* featured items still sends (`HasDataToSendAsync` accounts for them).
- The send clears the list; the queue is untouched.

Also: the test-mail renderer only covered `add/update/delete/upcoming`, so a test email could never show a Featured section. It now includes `featured`, which is how the header above was verified end to end.

Per CONTRIBUTING.md this was built locally against ImageSharp 3.1.12; the downgrade is not part of this diff.
