### PR TITLE
Group the newsletter preview into event sections and count entries rather than files

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -479,27 +479,6 @@
                 white-space: nowrap;
             }
 
-            .preview-badge {
-                border-radius: 3px;
-                padding: 2px 7px;
-                font-size: 0.72em;
-                text-transform: uppercase;
-                letter-spacing: 0.04em;
-                color: #fff;
-            }
-
-            .preview-badge.add {
-                background: #2e7d32;
-            }
-
-            .preview-badge.update {
-                background: #1565c0;
-            }
-
-            .preview-badge.delete {
-                background: #c62828;
-            }
-
             .preview-section {
                 margin-bottom: 22px;
             }
@@ -1707,11 +1686,12 @@
                     });
                     if (!inSection.length) return;
 
-                    // Entries are what the newsletter actually shows - one card per title. The
+                    // Entries are what the newsletter actually shows - one card per title, so
+                    // fully excluded titles are left out and excluded files are not counted. The
                     // file count only differs when a title covers several episodes, so it goes in
                     // parentheses and is dropped when the two are equal.
-                    var entries = inSection.length;
-                    var items = inSection.reduce(function (n, g) { return n + g.TotalCount; }, 0);
+                    var entries = inSection.filter(function (g) { return g.ExcludedCount < g.TotalCount; }).length;
+                    var items = inSection.reduce(function (n, g) { return n + (g.TotalCount - g.ExcludedCount); }, 0);
                     var countLabel = entries + ' ' + (entries === 1 ? 'entry' : 'entries');
                     if (items !== entries) {
                         countLabel += ' (' + items + ' item' + (items === 1 ? '' : 's') + ')';
@@ -1765,7 +1745,7 @@
                         var isEpisode = group.Type !== 'Movie' && item.Season >= 0 && item.Episode >= 0;
                         var label = isEpisode
                             ? 'S' + ('0' + item.Season).slice(-2) + 'E' + ('0' + item.Episode).slice(-2)
-                            : item.Filename.split('/').pop();
+                            : item.Filename.split(/[\\/]/).pop();
 
                         html += '<div class="preview-episode' + (item.Excluded ? ' preview-excluded' : '') + '"'
                             + ' data-preview-file="' + escapeHtml(item.Filename) + '">';

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -500,6 +500,35 @@
                 background: #c62828;
             }
 
+            .preview-section {
+                margin-bottom: 22px;
+            }
+
+            .preview-section-header {
+                font-size: 1.05em;
+                font-weight: 700;
+                letter-spacing: 0.4px;
+                padding-bottom: 6px;
+                margin-bottom: 10px;
+                border-bottom: 2px solid;
+            }
+
+            .preview-section-count {
+                font-weight: 400;
+                font-size: 0.8em;
+                opacity: 0.7;
+                margin-left: 6px;
+            }
+
+            /* Only groups with more than one file can expand, so only those look clickable. */
+            .preview-group-header {
+                cursor: default;
+            }
+
+            .preview-expandable > .preview-group-header {
+                cursor: pointer;
+            }
+
             .preview-episodes {
                 display: none;
                 border-top: 1px solid #444;
@@ -1665,61 +1694,93 @@
                     return;
                 }
 
+                var EVENT_SECTIONS = [
+                    { key: 'add', label: 'Added', color: '#2e7d32' },
+                    { key: 'update', label: 'Updated', color: '#1565c0' },
+                    { key: 'delete', label: 'Removed', color: '#c62828' }
+                ];
+
                 var html = '';
-                groups.forEach(function (group) {
-                    var key = previewGroupKey(group);
-                    var allExcluded = group.ExcludedCount === group.TotalCount;
-                    var eventType = (group.EventType || 'add').toLowerCase();
-                    var classes = 'preview-group' + (previewExpanded[key] ? ' expanded' : '')
-                        + (allExcluded ? ' preview-excluded' : '');
+                EVENT_SECTIONS.forEach(function (section) {
+                    var inSection = groups.filter(function (g) {
+                        return (g.EventType || 'add').toLowerCase() === section.key;
+                    });
+                    if (!inSection.length) return;
 
-                    var meta = [];
-                    if (group.SeasonSummary) meta.push(group.SeasonSummary);
-                    if (group.PremiereYear) meta.push(group.PremiereYear);
-                    if (group.LibraryName) meta.push(group.LibraryName);
-                    if (group.ExcludedCount && !allExcluded) {
-                        meta.push(group.ExcludedCount + ' of ' + group.TotalCount + ' excluded');
+                    // Entries are what the newsletter actually shows - one card per title. The
+                    // file count only differs when a title covers several episodes, so it goes in
+                    // parentheses and is dropped when the two are equal.
+                    var entries = inSection.length;
+                    var items = inSection.reduce(function (n, g) { return n + g.TotalCount; }, 0);
+                    var countLabel = entries + ' ' + (entries === 1 ? 'entry' : 'entries');
+                    if (items !== entries) {
+                        countLabel += ' (' + items + ' item' + (items === 1 ? '' : 's') + ')';
                     }
 
-                    html += '<div class="' + classes + '" data-preview-key="' + escapeHtml(key) + '">';
-                    html += '  <div class="preview-group-header" onclick="togglePreviewGroup(this)">';
-                    html += '    <span class="expand-icon">' + (group.TotalCount > 1 ? '&#9656;' : '&nbsp;') + '</span>';
-                    html += '    <span class="preview-badge ' + escapeHtml(eventType) + '">' + escapeHtml(eventType) + '</span>';
-                    html += '    <span class="preview-title">' + escapeHtml(group.Title) + '</span>';
-                    html += '    <span class="preview-meta">' + escapeHtml(meta.join(' · ')) + '</span>';
+                    html += '<div class="preview-section">';
+                    html += '  <div class="preview-section-header" style="color: ' + section.color
+                        + '; border-bottom-color: ' + section.color + ';">'
+                        + escapeHtml(section.label) + ' <span class="preview-section-count">'
+                        + escapeHtml(countLabel) + '</span></div>';
 
-                    if (allExcluded) {
-                        html += '    <button type="button" class="config-action-btn test-btn" onclick="event.stopPropagation(); setPreviewGroupExcluded(this, false)">Restore</button>';
-                    } else {
-                        html += '    <button type="button" class="config-action-btn delete-btn" onclick="event.stopPropagation(); setPreviewGroupExcluded(this, true)">Remove</button>';
-                    }
-
-                    html += '  </div>';
-
-                    if (group.TotalCount > 1) {
-                        html += '  <div class="preview-episodes">';
-                        group.Items.forEach(function (item) {
-                            var isEpisode = group.Type !== 'Movie' && item.Season >= 0 && item.Episode >= 0;
-                            var label = isEpisode
-                                ? 'S' + ('0' + item.Season).slice(-2) + 'E' + ('0' + item.Episode).slice(-2)
-                                : item.Filename.split(/[\\/]/).pop();
-
-                            html += '<div class="preview-episode' + (item.Excluded ? ' preview-excluded' : '') + '"'
-                                + ' data-preview-file="' + escapeHtml(item.Filename) + '">';
-                            html += '  <span class="preview-episode-label" title="' + escapeHtml(item.Filename) + '">'
-                                + escapeHtml(label) + '</span>';
-                            html += item.Excluded
-                                ? '  <button type="button" class="config-action-btn test-btn" onclick="setPreviewItemExcluded(this, false)">Restore</button>'
-                                : '  <button type="button" class="config-action-btn delete-btn" onclick="setPreviewItemExcluded(this, true)">Remove</button>';
-                            html += '</div>';
-                        });
-                        html += '  </div>';
-                    }
+                    inSection.forEach(function (group) {
+                        html += renderPreviewGroup(group);
+                    });
 
                     html += '</div>';
                 });
 
                 list.innerHTML = html;
+            }
+
+            function renderPreviewGroup(group) {
+                var key = previewGroupKey(group);
+                var allExcluded = group.ExcludedCount === group.TotalCount;
+                var expandable = group.TotalCount > 1;
+                var classes = 'preview-group' + (previewExpanded[key] ? ' expanded' : '')
+                    + (allExcluded ? ' preview-excluded' : '')
+                    + (expandable ? ' preview-expandable' : '');
+
+                var meta = [];
+                if (group.SeasonSummary) meta.push(group.SeasonSummary);
+                if (group.PremiereYear) meta.push(group.PremiereYear);
+                if (group.LibraryName) meta.push(group.LibraryName);
+                if (group.ExcludedCount && !allExcluded) {
+                    meta.push(group.ExcludedCount + ' of ' + group.TotalCount + ' excluded');
+                }
+
+                var html = '<div class="' + classes + '" data-preview-key="' + escapeHtml(key) + '">';
+                html += '  <div class="preview-group-header" onclick="togglePreviewGroup(this)">';
+                html += '    <span class="expand-icon">' + (expandable ? '&#9656;' : '&nbsp;') + '</span>';
+                html += '    <span class="preview-title">' + escapeHtml(group.Title) + '</span>';
+                html += '    <span class="preview-meta">' + escapeHtml(meta.join(' \u00b7 ')) + '</span>';
+                html += allExcluded
+                    ? '    <button type="button" class="config-action-btn test-btn" onclick="event.stopPropagation(); setPreviewGroupExcluded(this, false)">Restore</button>'
+                    : '    <button type="button" class="config-action-btn delete-btn" onclick="event.stopPropagation(); setPreviewGroupExcluded(this, true)">Remove</button>';
+                html += '  </div>';
+
+                if (expandable) {
+                    html += '  <div class="preview-episodes">';
+                    group.Items.forEach(function (item) {
+                        var isEpisode = group.Type !== 'Movie' && item.Season >= 0 && item.Episode >= 0;
+                        var label = isEpisode
+                            ? 'S' + ('0' + item.Season).slice(-2) + 'E' + ('0' + item.Episode).slice(-2)
+                            : item.Filename.split('/').pop();
+
+                        html += '<div class="preview-episode' + (item.Excluded ? ' preview-excluded' : '') + '"'
+                            + ' data-preview-file="' + escapeHtml(item.Filename) + '">';
+                        html += '  <span class="preview-episode-label" title="' + escapeHtml(item.Filename) + '">'
+                            + escapeHtml(label) + '</span>';
+                        html += item.Excluded
+                            ? '  <button type="button" class="config-action-btn test-btn" onclick="setPreviewItemExcluded(this, false)">Restore</button>'
+                            : '  <button type="button" class="config-action-btn delete-btn" onclick="setPreviewItemExcluded(this, true)">Remove</button>';
+                        html += '</div>';
+                    });
+                    html += '  </div>';
+                }
+
+                html += '</div>';
+                return html;
             }
 
             function togglePreviewGroup(headerEl) {


### PR DESCRIPTION
Follow-up to #109, which is now merged. Presentation only — no C# changes.

## What this changes

**1. Group the preview by event type, with the heading above its entries.**

The preview listed every queued title in one flat run, with a small `add` / `update` / `delete` badge on each card. The newsletter itself renders a heading per event type and then the entries beneath it, so the preview now mirrors that:

```
Added    3 entries (88 items)
  ▸ Ted Lasso            S4 E1-10 · 2020 · Shows
  ▸ The Office           S1 E1-6 · 2005 · Shows
    Minions & Monsters   2024 · Movies

Updated  1 entry (3 items)
  ▸ Weeds                S2 E3, 7-8 · 2005 · Shows
```

The per-card badge is gone, since the heading now carries that information and repeating it on every row was noise. Headings are colour-matched to the existing badge colours.

**2. Count entries, not files.**

The queue stores one row per file, so a season of a show counted as its episodes. A week with three titles read as "88 items", which does not correspond to anything the reader of the newsletter will see — the newsletter shows three entries. The heading now reports entries, with the file count in parentheses only when the two differ:

- `3 entries (88 items)` — three cards covering 88 files
- `2 entries` — two movies, so the file count adds nothing

**3. Only expandable groups look interactive.**

A single-file group has no child list, so clicking it did nothing while still showing a pointer cursor and a caret-sized gap. The caret and the pointer cursor are now applied only when `TotalCount > 1`, via a `preview-expandable` class.

## Testing

Running on Jellyfin 10.11.11 against a real queue of 91 files across 4 titles:

- Sections render in add → update → delete order, and a section with no entries is omitted entirely.
- `3 entries (88 items)` and `1 entry (3 items)` — verified against the API payload.
- Every group renders collapsed; expand and collapse both work on multi-file groups.
- The single-file group shows no caret and does not respond to clicks.
- Exclude and restore still work at both group and episode level.
