### PR TITLE
Add Discord mentions support for roles, users, @here and @everyone

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Clients/Discord/DiscordPayload.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Discord/DiscordPayload.cs
@@ -19,4 +19,11 @@ public class DiscordPayload
     /// </summary>
     [JsonPropertyName("embeds")]
     public ReadOnlyCollection<Embed>? Embeds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the plain text message content, used to carry the configured mentions.
+    /// </summary>
+    [JsonPropertyName("content")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Content { get; set; }
 }

--- a/Jellyfin.Plugin.Newsletters/Clients/Discord/DiscordWebhook.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Discord/DiscordWebhook.cs
@@ -98,6 +98,8 @@ public class DiscordWebhook(IServerApplicationHost appHost,
 
         bool anySuccess = false;
 
+        var mentionContent = BuildMentionContent(discordConfig);
+
         foreach (var webhookUrl in webhookUrls)
         {
             try
@@ -108,7 +110,8 @@ public class DiscordWebhook(IServerApplicationHost appHost,
                 var payload = new DiscordPayload
                 {
                     Username = discordConfig.WebhookName,
-                    Embeds = embedList
+                    Embeds = embedList,
+                    Content = string.IsNullOrEmpty(mentionContent) ? null : mentionContent
                 };
 
                 var jsonPayload = System.Text.Json.JsonSerializer.Serialize(payload);
@@ -261,19 +264,26 @@ public class DiscordWebhook(IServerApplicationHost appHost,
                 chunks.Add(chunk);
             }
 
+            var mentionContent = BuildMentionContent(discordConfig);
+
             // Iterate over each webhook URL and send the pre-calculated chunks
             foreach (var webhookUrl in webhookUrls)
             {
                 Logger.Debug($"Sending Discord newsletter to '{discordConfig.Name}' (URL: {webhookUrl})");
 
+                // Mentions are only attached to the first successfully sent chunk of each webhook,
+                // otherwise a multi chunk newsletter would notify members once per chunk.
+                bool mentionPending = !string.IsNullOrEmpty(mentionContent);
+
                 foreach (var chunk in chunks)
                 {
-                    try 
+                    try
                     {
                         var payload = new DiscordPayload
                         {
                             Username = discordConfig.WebhookName,
-                            Embeds = new Collection<Embed>(chunk.Select(t => t.Item1).ToList()).AsReadOnly()
+                            Embeds = new Collection<Embed>(chunk.Select(t => t.Item1).ToList()).AsReadOnly(),
+                            Content = mentionPending ? mentionContent : null
                         };
 
                         var jsonPayload = System.Text.Json.JsonSerializer.Serialize(payload);
@@ -304,6 +314,9 @@ public class DiscordWebhook(IServerApplicationHost appHost,
                         {
                             // Track any successful chunk
                             anyResult = true;
+
+                            // Only stop attaching mentions once a chunk carrying them actually went through
+                            mentionPending = false;
                             Logger.Debug($"Discord message chunk sent successfully to '{discordConfig.Name}' (URL: {webhookUrl})");
                         }
                         else
@@ -325,6 +338,19 @@ public class DiscordWebhook(IServerApplicationHost appHost,
         }
 
         return anyResult;
+    }
+
+    /// <summary>
+    /// Builds the message content carrying the configured mentions.
+    /// Commas are only a separator in the configuration, Discord parses the mentions from the content itself.
+    /// </summary>
+    /// <param name="discordConfig">The Discord configuration to read the mentions from.</param>
+    /// <returns>The space separated mentions, empty when none are configured.</returns>
+    private static string BuildMentionContent(DiscordConfiguration discordConfig)
+    {
+        return string.Join(' ', discordConfig.Mentions.Split(',')
+                                                      .Select(m => m.Trim())
+                                                      .Where(m => !string.IsNullOrEmpty(m)));
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Newsletters/Configuration/DiscordConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/DiscordConfiguration.cs
@@ -34,6 +34,11 @@ public class DiscordConfiguration : INewsletterConfiguration
     public string WebhookName { get; set; } = "Jellyfin Newsletter";
 
     /// <summary>
+    /// Gets or sets the comma separated list of Discord mention targets (@everyone, @here, role ids or user ids).
+    /// </summary>
+    public string Mentions { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets a value indicating whether description should be visible in Discord embed.
     /// </summary>
     public bool DescriptionEnabled { get; set; } = true;

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -912,6 +912,7 @@
                     IsEnabled: true,
                     WebhookURL: '',
                     WebhookName: 'Jellyfin Newsletter',
+                    Mentions: '',
                     DescriptionEnabled: true,
                     ThumbnailEnabled: true,
                     RatingEnabled: true,
@@ -984,6 +985,7 @@
                 config.IsEnabled = document.getElementById('discord-enabled-' + id).checked;
                 config.WebhookURL = document.getElementById('discord-url-' + id).value;
                 config.WebhookName = document.getElementById('discord-webhookname-' + id).value;
+                config.Mentions = document.getElementById('discord-mentions-' + id).value;
                 config.DescriptionEnabled = document.getElementById('discord-desc-' + id).checked;
                 config.ThumbnailEnabled = document.getElementById('discord-thumb-' + id).checked;
                 config.RatingEnabled = document.getElementById('discord-rating-' + id).checked;
@@ -1059,6 +1061,11 @@
                     html += '    <div class="inputContainer">';
                     html += '      <label class="inputLabel inputLabelUnfocused">Webhook Display Name:</label>';
                     html += '      <input id="discord-webhookname-' + config.Id + '" type="text" is="emby-input" value="' + (config.WebhookName || '') + '" onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')" />';
+                    html += '    </div>';
+                    html += '    <div class="inputContainer">';
+                    html += '      <label class="inputLabel inputLabelUnfocused">Mentions:</label>';
+                    html += '      <input id="discord-mentions-' + config.Id + '" type="text" is="emby-input" value="' + (config.Mentions || '') + '" onchange="updateDiscordConfigFromUI(\'' + config.Id + '\')" />';
+                    html += '      <div class="fieldDescription">Who to ping when this newsletter is posted. Separate multiple entries with commas, for example: @everyone, @here, &lt;@&amp;ROLE_ID&gt;, &lt;@USER_ID&gt;. Enable Developer Mode in Discord to copy role and user IDs. The mention is posted once per webhook, on the first message of the newsletter. Leave empty to post without pinging.</div>';
                     html += '    </div>';
                     html += getLibrarySelectionHtml(config.Id, 'discord', config.SelectedSeriesLibraries, config.SelectedMoviesLibraries);
                     html += getEventTogglesHtml(config.Id, 'discord', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled, config.NewsletterOnFeaturedEnabled);


### PR DESCRIPTION
This PR closes #114 and contains the following changes:

- Adds a per-configuration "Mentions" field so a newsletter can notify specific roles or users, or the whole channel/server, when it is posted.
- Entries are comma separated in the configuration and joined into the message content, which is what Discord parses mentions from. Accepted entries are @everyone, @here, <@&ROLE_ID> and <@USER_ID>.