### PR TITLE
Add library media count tags for newsletter templates

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Clients/Client.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Client.cs
@@ -117,11 +117,11 @@ public class Client(Logger loggerInstance,
                 continue;
             }
 
-            // Copied, not assigned: configurations with the same library selection share one
-            // cached snapshot, so assigning its collections directly would leave several
-            // configurations holding the same mutable lists.
-            templatedConfig.PrevMovieLibraryCounts = Copy(snapshot.MovieLibraries);
-            templatedConfig.PrevSeriesLibraryCounts = Copy(snapshot.SeriesLibraries);
+            // Contents replaced rather than the collection assigned: configurations with the
+            // same library selection share one cached snapshot, so handing over its collections
+            // would leave several configurations holding the same mutable lists.
+            ReplaceAll(templatedConfig.PrevMovieLibraryCounts, snapshot.MovieLibraries);
+            ReplaceAll(templatedConfig.PrevSeriesLibraryCounts, snapshot.SeriesLibraries);
         }
 
         // The next cycle must re-query rather than reuse what we just stored.
@@ -129,25 +129,28 @@ public class Client(Logger loggerInstance,
     }
 
     /// <summary>
-    /// Copies stored counts so each configuration owns its own rows.
+    /// Replaces a configuration's stored counts with fresh rows of its own.
     /// </summary>
-    /// <param name="source">The rows to copy.</param>
-    /// <returns>A new collection of new rows.</returns>
-    private static Collection<StoredLibraryCount> Copy(Collection<StoredLibraryCount> source)
+    /// <param name="target">The configuration's stored counts.</param>
+    /// <param name="source">The rows to copy in.</param>
+    private static void ReplaceAll(Collection<StoredLibraryCount> target, Collection<StoredLibraryCount> source)
     {
-        var copy = new Collection<StoredLibraryCount>();
+        if (target is null)
+        {
+            return;
+        }
+
+        target.Clear();
 
         foreach (var entry in source)
         {
-            copy.Add(new StoredLibraryCount
+            target.Add(new StoredLibraryCount
             {
                 LibraryId = entry.LibraryId,
                 Titles = entry.Titles,
                 Episodes = entry.Episodes
             });
         }
-
-        return copy;
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Newsletters/Clients/Client.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Client.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Newsletters.Configuration;
 using Jellyfin.Plugin.Newsletters.Featured;
 using Jellyfin.Plugin.Newsletters.Integrations;
+using Jellyfin.Plugin.Newsletters.Shared;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
 using Jellyfin.Plugin.Newsletters.Shared.Entities;
 using MediaBrowser.Controller.Library;
@@ -71,6 +73,11 @@ public class Client(Logger loggerInstance,
                 FeaturedItems.ClearPosterCache();
             }
 
+            // Snapshot each configuration's library counts so the next newsletter can report the
+            // change since this one. Every config carries its own library selection, so the counts
+            // are resolved per config rather than once server-wide.
+            CaptureLibraryCounts();
+
             // Update and save the last published date
             Config.LastPublishedDate = DateTime.Now;
             Plugin.Instance!.SaveConfiguration();
@@ -83,6 +90,38 @@ public class Client(Logger loggerInstance,
         {
             Db.CloseConnection();
         }
+    }
+
+    /// <summary>
+    /// Records the current library counts on every templated configuration.
+    /// </summary>
+    /// <remarks>
+    /// Disabled configurations are snapshotted too. "Previous" means "as of the last newsletter
+    /// cycle", so skipping them would make the first delta after re-enabling one enormous.
+    /// </remarks>
+    private void CaptureLibraryCounts()
+    {
+        var templatedConfigs = Config.EmailConfigurations.Cast<ITemplatedConfiguration>()
+            .Concat(Config.MatrixConfigurations);
+
+        foreach (var templatedConfig in templatedConfigs)
+        {
+            var counts = LibraryStats.GetCounts(LibraryManager, Logger, templatedConfig);
+            if (counts is null)
+            {
+                // Storing zeros here would make the next newsletter report the whole library as
+                // newly added. Keeping the older baseline is the less wrong answer.
+                Logger.Warn("Could not count library items - keeping the previous baseline for this configuration.");
+                continue;
+            }
+
+            templatedConfig.PrevMovieCount = counts.Movies;
+            templatedConfig.PrevSeriesCount = counts.Series;
+            templatedConfig.PrevEpisodeCount = counts.Episodes;
+        }
+
+        // The next cycle must re-query rather than reuse what we just stored.
+        LibraryStats.ClearCache();
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Newsletters/Clients/Client.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Client.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,6 +10,7 @@ using Jellyfin.Plugin.Newsletters.Integrations;
 using Jellyfin.Plugin.Newsletters.Shared;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
 using Jellyfin.Plugin.Newsletters.Shared.Entities;
+using Jellyfin.Plugin.Newsletters.Shared.Models;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Mvc;
 
@@ -106,8 +108,8 @@ public class Client(Logger loggerInstance,
 
         foreach (var templatedConfig in templatedConfigs)
         {
-            var counts = LibraryStats.GetCounts(LibraryManager, Logger, templatedConfig);
-            if (counts is null)
+            var snapshot = LibraryStats.GetSnapshot(LibraryManager, Logger, templatedConfig);
+            if (snapshot is null)
             {
                 // Storing zeros here would make the next newsletter report the whole library as
                 // newly added. Keeping the older baseline is the less wrong answer.
@@ -115,13 +117,37 @@ public class Client(Logger loggerInstance,
                 continue;
             }
 
-            templatedConfig.PrevMovieCount = counts.Movies;
-            templatedConfig.PrevSeriesCount = counts.Series;
-            templatedConfig.PrevEpisodeCount = counts.Episodes;
+            // Copied, not assigned: configurations with the same library selection share one
+            // cached snapshot, so assigning its collections directly would leave several
+            // configurations holding the same mutable lists.
+            templatedConfig.PrevMovieLibraryCounts = Copy(snapshot.MovieLibraries);
+            templatedConfig.PrevSeriesLibraryCounts = Copy(snapshot.SeriesLibraries);
         }
 
         // The next cycle must re-query rather than reuse what we just stored.
         LibraryStats.ClearCache();
+    }
+
+    /// <summary>
+    /// Copies stored counts so each configuration owns its own rows.
+    /// </summary>
+    /// <param name="source">The rows to copy.</param>
+    /// <returns>A new collection of new rows.</returns>
+    private static Collection<StoredLibraryCount> Copy(Collection<StoredLibraryCount> source)
+    {
+        var copy = new Collection<StoredLibraryCount>();
+
+        foreach (var entry in source)
+        {
+            copy.Add(new StoredLibraryCount
+            {
+                LibraryId = entry.LibraryId,
+                Titles = entry.Titles,
+                Episodes = entry.Episodes
+            });
+        }
+
+        return copy;
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Newsletters/Clients/Email/SmtpMailer.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Email/SmtpMailer.cs
@@ -119,8 +119,7 @@ public class SmtpMailer(IServerApplicationHost appHost,
 
             string body = hb.GetDefaultHTMLBody(emailConfig);
             string builtString = hb.BuildHtmlStringsForTest(emailConfig);
-            builtString = hb.TemplateReplace(HtmlBuilder.ReplaceBodyWithBuiltString(body, builtString), "{ServerURL}", Config.Hostname);
-            builtString = hb.ReplaceDatePlaceholders(builtString);
+            builtString = hb.ReplaceBodyPlaceholders(HtmlBuilder.ReplaceBodyWithBuiltString(body, builtString), emailConfig);
 
             var mail = new MimeMessage();
             mail.From.Add(new MailboxAddress(emailFromAddress, emailFromAddress));
@@ -297,8 +296,8 @@ public class SmtpMailer(IServerApplicationHost appHost,
                 {
                     Logger.Debug($"Email part {partNum} for '{emailConfig.Name}' image count: {inlineImages.Count}");
                     // Add template substitutions
-                    string finalBody = hb.ReplaceDatePlaceholders(
-                        hb.TemplateReplace(HtmlBuilder.ReplaceBodyWithBuiltString(body, builtString), "{ServerURL}", Config.Hostname));
+                    string finalBody = hb.ReplaceBodyPlaceholders(
+                        HtmlBuilder.ReplaceBodyWithBuiltString(body, builtString), emailConfig);
 
                     var mail = new MimeMessage();
                     mail.From.Add(new MailboxAddress(emailFromAddress, emailFromAddress));

--- a/Jellyfin.Plugin.Newsletters/Clients/Email/SmtpMailer.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Email/SmtpMailer.cs
@@ -119,7 +119,7 @@ public class SmtpMailer(IServerApplicationHost appHost,
 
             string body = hb.GetDefaultHTMLBody(emailConfig);
             string builtString = hb.BuildHtmlStringsForTest(emailConfig);
-            builtString = hb.ReplaceBodyPlaceholders(HtmlBuilder.ReplaceBodyWithBuiltString(body, builtString), emailConfig);
+            builtString = hb.ReplaceBodyPlaceholders(HtmlBuilder.ReplaceBodyWithBuiltString(body, builtString), emailConfig, isTest: true);
 
             var mail = new MimeMessage();
             mail.From.Add(new MailboxAddress(emailFromAddress, emailFromAddress));

--- a/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
@@ -176,12 +176,13 @@ public abstract class HtmlContentBuilder(
     /// </summary>
     /// <param name="html">The built newsletter body.</param>
     /// <param name="config">The configuration the newsletter is being rendered for.</param>
+    /// <param name="isTest">Whether this is a test newsletter, which uses sample counts.</param>
     /// <returns>The body with every body-level placeholder resolved.</returns>
-    public string ReplaceBodyPlaceholders(string html, ITemplatedConfiguration config)
+    public string ReplaceBodyPlaceholders(string html, ITemplatedConfiguration config, bool isTest = false)
     {
         html = this.TemplateReplace(html, "{ServerURL}", Config.Hostname);
         html = ReplaceDatePlaceholders(html);
-        return ReplaceStatPlaceholders(html, config);
+        return ReplaceStatPlaceholders(html, config, isTest);
     }
 
     /// <summary>
@@ -189,17 +190,32 @@ public abstract class HtmlContentBuilder(
     /// </summary>
     /// <param name="html">The string containing count placeholders to replace.</param>
     /// <param name="config">The configuration whose library selection defines the counts.</param>
+    /// <param name="isTest">Whether this is a test newsletter, which uses sample counts.</param>
     /// <returns>The string with all count placeholders resolved.</returns>
-    public string ReplaceStatPlaceholders(string html, ITemplatedConfiguration config)
+    public string ReplaceStatPlaceholders(string html, ITemplatedConfiguration config, bool isTest = false)
     {
-        // A failed library query still has to render something; zeros beat leaving raw tags in the email.
-        var current = LibraryStats.GetCounts(LibraryManager, Logger, config) ?? new LibraryCounts(0, 0, 0);
+        LibraryCounts current;
+        LibraryCounts previous;
 
-        // Before the first send there is nothing to compare against. Falling back to the current
-        // counts makes every delta 0, rather than reporting the whole library as newly added.
-        var previous = config.PrevMovieCount.HasValue && config.PrevSeriesCount.HasValue && config.PrevEpisodeCount.HasValue
-            ? new LibraryCounts(config.PrevMovieCount.Value, config.PrevSeriesCount.Value, config.PrevEpisodeCount.Value)
-            : current;
+        if (isTest)
+        {
+            // A test newsletter is built from sample entries, so real library totals would sit
+            // oddly beside them - and a config with no libraries selected would render all zeros.
+            // Sample counts against a zero baseline show what the tags look like in use.
+            current = LibraryCounts.GetTestObj();
+            previous = new LibraryCounts(0, 0, 0);
+        }
+        else
+        {
+            // A failed library query still has to render something; zeros beat leaving raw tags in the email.
+            current = LibraryStats.GetCounts(LibraryManager, Logger, config) ?? new LibraryCounts(0, 0, 0);
+
+            // Before the first send there is nothing to compare against. Falling back to the current
+            // counts makes every delta 0, rather than reporting the whole library as newly added.
+            previous = config.PrevMovieCount.HasValue && config.PrevSeriesCount.HasValue && config.PrevEpisodeCount.HasValue
+                ? new LibraryCounts(config.PrevMovieCount.Value, config.PrevSeriesCount.Value, config.PrevEpisodeCount.Value)
+                : current;
+        }
 
         html = this.TemplateReplace(html, "{MovieCount}", current.Movies);
         html = this.TemplateReplace(html, "{SeriesCount}", current.Series);

--- a/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
@@ -11,6 +11,7 @@ using Jellyfin.Plugin.Newsletters.Integrations;
 using Jellyfin.Plugin.Newsletters.Shared;
 using Jellyfin.Plugin.Newsletters.Shared.Database;
 using Jellyfin.Plugin.Newsletters.Shared.Entities;
+using Jellyfin.Plugin.Newsletters.Shared.Models;
 using MediaBrowser.Controller.Library;
 using Newtonsoft.Json;
 
@@ -168,6 +169,66 @@ public abstract class HtmlContentBuilder(
         html = ReplaceDatePlaceholdersInternal(html, DateTime.Today, string.Empty);
         html = ReplaceDatePlaceholdersInternal(html, Config.LastPublishedDate, "prev");
         return html;
+    }
+
+    /// <summary>
+    /// Replaces the {ServerURL}, date, and library-count placeholders in a fully built newsletter body.
+    /// </summary>
+    /// <param name="html">The built newsletter body.</param>
+    /// <param name="config">The configuration the newsletter is being rendered for.</param>
+    /// <returns>The body with every body-level placeholder resolved.</returns>
+    public string ReplaceBodyPlaceholders(string html, ITemplatedConfiguration config)
+    {
+        html = this.TemplateReplace(html, "{ServerURL}", Config.Hostname);
+        html = ReplaceDatePlaceholders(html);
+        return ReplaceStatPlaceholders(html, config);
+    }
+
+    /// <summary>
+    /// Replaces the library-count placeholders using the libraries selected on the given configuration.
+    /// </summary>
+    /// <param name="html">The string containing count placeholders to replace.</param>
+    /// <param name="config">The configuration whose library selection defines the counts.</param>
+    /// <returns>The string with all count placeholders resolved.</returns>
+    public string ReplaceStatPlaceholders(string html, ITemplatedConfiguration config)
+    {
+        // A failed library query still has to render something; zeros beat leaving raw tags in the email.
+        var current = LibraryStats.GetCounts(LibraryManager, Logger, config) ?? new LibraryCounts(0, 0, 0);
+
+        // Before the first send there is nothing to compare against. Falling back to the current
+        // counts makes every delta 0, rather than reporting the whole library as newly added.
+        var previous = config.PrevMovieCount.HasValue && config.PrevSeriesCount.HasValue && config.PrevEpisodeCount.HasValue
+            ? new LibraryCounts(config.PrevMovieCount.Value, config.PrevSeriesCount.Value, config.PrevEpisodeCount.Value)
+            : current;
+
+        html = this.TemplateReplace(html, "{MovieCount}", current.Movies);
+        html = this.TemplateReplace(html, "{SeriesCount}", current.Series);
+        html = this.TemplateReplace(html, "{EpisodeCount}", current.Episodes);
+        html = this.TemplateReplace(html, "{ItemCount}", current.Items);
+
+        html = this.TemplateReplace(html, "{prevMovieCount}", previous.Movies);
+        html = this.TemplateReplace(html, "{prevSeriesCount}", previous.Series);
+        html = this.TemplateReplace(html, "{prevEpisodeCount}", previous.Episodes);
+        html = this.TemplateReplace(html, "{prevItemCount}", previous.Items);
+
+        html = this.TemplateReplace(html, "{newMovieCount}", Signed(current.Movies - previous.Movies));
+        html = this.TemplateReplace(html, "{newSeriesCount}", Signed(current.Series - previous.Series));
+        html = this.TemplateReplace(html, "{newEpisodeCount}", Signed(current.Episodes - previous.Episodes));
+        html = this.TemplateReplace(html, "{newItemCount}", Signed(current.Items - previous.Items));
+
+        return html;
+    }
+
+    /// <summary>
+    /// Formats a delta with an explicit sign so a template never has to hardcode one.
+    /// A hardcoded '+' would read as "+-3" once items are deleted.
+    /// </summary>
+    /// <param name="value">The delta to format.</param>
+    /// <returns>"+2" when positive, "-3" when negative, "0" when unchanged.</returns>
+    private static string Signed(int value)
+    {
+        string text = value.ToString(CultureInfo.InvariantCulture);
+        return value > 0 ? "+" + text : text;
     }
 
     private string ReplaceDatePlaceholdersInternal(string html, DateTime? date, string prefix)

--- a/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
@@ -195,7 +195,7 @@ public abstract class HtmlContentBuilder(
     public string ReplaceStatPlaceholders(string html, ITemplatedConfiguration config, bool isTest = false)
     {
         LibraryCounts current;
-        LibraryCounts previous;
+        LibraryCounts delta;
 
         if (isTest)
         {
@@ -203,19 +203,26 @@ public abstract class HtmlContentBuilder(
             // oddly beside them - and a config with no libraries selected would render all zeros.
             // Sample counts against a zero baseline show what the tags look like in use.
             current = LibraryCounts.GetTestObj();
-            previous = new LibraryCounts(0, 0, 0);
+            delta = current;
         }
         else
         {
-            // A failed library query still has to render something; zeros beat leaving raw tags in the email.
-            current = LibraryStats.GetCounts(LibraryManager, Logger, config) ?? new LibraryCounts(0, 0, 0);
+            // A failed library walk still has to render something; zeros beat leaving raw tags in the email.
+            var snapshot = LibraryStats.GetSnapshot(LibraryManager, Logger, config) ?? new LibraryStats.Snapshot();
+            current = snapshot.Totals;
 
-            // Before the first send there is nothing to compare against. Falling back to the current
-            // counts makes every delta 0, rather than reporting the whole library as newly added.
-            previous = config.PrevMovieCount.HasValue && config.PrevSeriesCount.HasValue && config.PrevEpisodeCount.HasValue
-                ? new LibraryCounts(config.PrevMovieCount.Value, config.PrevSeriesCount.Value, config.PrevEpisodeCount.Value)
-                : current;
+            // Compared library by library, so a change to this configuration's library selection
+            // cannot masquerade as items being added or removed. Before the first send nothing
+            // matches, which leaves every delta at 0 rather than reporting the whole library as new.
+            delta = snapshot.DeltaFrom(config.PrevMovieLibraryCounts, config.PrevSeriesLibraryCounts);
         }
+
+        // Derived rather than stored: it keeps {prevX} + {newX} == {X} in the rendered newsletter
+        // even when a library joined or left the selection and is therefore absent from the delta.
+        var previous = new LibraryCounts(
+            current.Movies - delta.Movies,
+            current.Series - delta.Series,
+            current.Episodes - delta.Episodes);
 
         html = this.TemplateReplace(html, "{MovieCount}", current.Movies);
         html = this.TemplateReplace(html, "{SeriesCount}", current.Series);
@@ -227,10 +234,10 @@ public abstract class HtmlContentBuilder(
         html = this.TemplateReplace(html, "{prevEpisodeCount}", previous.Episodes);
         html = this.TemplateReplace(html, "{prevItemCount}", previous.Items);
 
-        html = this.TemplateReplace(html, "{newMovieCount}", Signed(current.Movies - previous.Movies));
-        html = this.TemplateReplace(html, "{newSeriesCount}", Signed(current.Series - previous.Series));
-        html = this.TemplateReplace(html, "{newEpisodeCount}", Signed(current.Episodes - previous.Episodes));
-        html = this.TemplateReplace(html, "{newItemCount}", Signed(current.Items - previous.Items));
+        html = this.TemplateReplace(html, "{newMovieCount}", Signed(delta.Movies));
+        html = this.TemplateReplace(html, "{newSeriesCount}", Signed(delta.Series));
+        html = this.TemplateReplace(html, "{newEpisodeCount}", Signed(delta.Episodes));
+        html = this.TemplateReplace(html, "{newItemCount}", Signed(delta.Items));
 
         return html;
     }

--- a/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixClient.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixClient.cs
@@ -102,7 +102,7 @@ public class MatrixClient(IServerApplicationHost appHost,
         {
             var builder = new MatrixMessageBuilder(Logger, Db, LibraryManager, new List<JsonFileObj>());
             var htmlBody = builder.BuildMessageForTest(matrixConfig);
-            htmlBody = builder.ReplaceBodyPlaceholders(htmlBody, matrixConfig);
+            htmlBody = builder.ReplaceBodyPlaceholders(htmlBody, matrixConfig, isTest: true);
 
             bool anySuccess = false;
             foreach (var roomId in roomIds)

--- a/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixClient.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixClient.cs
@@ -102,8 +102,7 @@ public class MatrixClient(IServerApplicationHost appHost,
         {
             var builder = new MatrixMessageBuilder(Logger, Db, LibraryManager, new List<JsonFileObj>());
             var htmlBody = builder.BuildMessageForTest(matrixConfig);
-            htmlBody = builder.TemplateReplace(htmlBody, "{ServerURL}", Config.Hostname);
-            htmlBody = builder.ReplaceDatePlaceholders(htmlBody);
+            htmlBody = builder.ReplaceBodyPlaceholders(htmlBody, matrixConfig);
 
             bool anySuccess = false;
             foreach (var roomId in roomIds)
@@ -182,8 +181,7 @@ public class MatrixClient(IServerApplicationHost appHost,
 
                     var builder = new MatrixMessageBuilder(Logger, Db, LibraryManager, matrixConfig.NewsletterOnUpcomingItemEnabled ? upcomingItems : Array.Empty<JsonFileObj>());
                     var htmlBody = builder.BuildMessageFromNewsletterData(applicationHost.SystemId, matrixConfig);
-                    htmlBody = builder.TemplateReplace(htmlBody, "{ServerURL}", Config.Hostname);
-                    htmlBody = builder.ReplaceDatePlaceholders(htmlBody);
+                    htmlBody = builder.ReplaceBodyPlaceholders(htmlBody, matrixConfig);
 
                     foreach (var roomId in roomIds)
                     {

--- a/Jellyfin.Plugin.Newsletters/Configuration/EmailConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/EmailConfiguration.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.ObjectModel;
 
+using Jellyfin.Plugin.Newsletters.Shared.Models;
+
 namespace Jellyfin.Plugin.Newsletters.Configuration;
 
 /// <summary>
@@ -137,17 +139,12 @@ public class EmailConfiguration : ITemplatedConfiguration
     public int MaxItemsPerSection { get; set; } = 0;
 
     /// <summary>
-    /// Gets or sets the movie count captured when the last newsletter was sent.
+    /// Gets or sets the per-library movie counts captured when the last newsletter was sent.
     /// </summary>
-    public int? PrevMovieCount { get; set; }
+    public Collection<StoredLibraryCount> PrevMovieLibraryCounts { get; set; } = new Collection<StoredLibraryCount>();
 
     /// <summary>
-    /// Gets or sets the series count captured when the last newsletter was sent.
+    /// Gets or sets the per-library series and episode counts captured when the last newsletter was sent.
     /// </summary>
-    public int? PrevSeriesCount { get; set; }
-
-    /// <summary>
-    /// Gets or sets the episode count captured when the last newsletter was sent.
-    /// </summary>
-    public int? PrevEpisodeCount { get; set; }
+    public Collection<StoredLibraryCount> PrevSeriesLibraryCounts { get; set; } = new Collection<StoredLibraryCount>();
 }

--- a/Jellyfin.Plugin.Newsletters/Configuration/EmailConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/EmailConfiguration.cs
@@ -135,4 +135,19 @@ public class EmailConfiguration : ITemplatedConfiguration
     /// A value of 0 means unlimited (default).
     /// </summary>
     public int MaxItemsPerSection { get; set; } = 0;
+
+    /// <summary>
+    /// Gets or sets the movie count captured when the last newsletter was sent.
+    /// </summary>
+    public int? PrevMovieCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the series count captured when the last newsletter was sent.
+    /// </summary>
+    public int? PrevSeriesCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the episode count captured when the last newsletter was sent.
+    /// </summary>
+    public int? PrevEpisodeCount { get; set; }
 }

--- a/Jellyfin.Plugin.Newsletters/Configuration/ITemplatedConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/ITemplatedConfiguration.cs
@@ -1,3 +1,9 @@
+// Collection properties need setters so the plugin configuration can be XML-serialized,
+// the same reason PluginConfiguration suppresses these.
+#pragma warning disable CA2227
+using System.Collections.ObjectModel;
+using Jellyfin.Plugin.Newsletters.Shared.Models;
+
 namespace Jellyfin.Plugin.Newsletters.Configuration;
 
 /// <summary>
@@ -29,20 +35,14 @@ public interface ITemplatedConfiguration : INewsletterConfiguration
     string Header { get; }
 
     /// <summary>
-    /// Gets or sets the number of movies these libraries held when the last newsletter was sent.
-    /// Null when no newsletter has been sent yet.
+    /// Gets or sets the per-library movie counts captured when the last newsletter was sent.
+    /// Empty until the first newsletter has been sent.
     /// </summary>
-    int? PrevMovieCount { get; set; }
+    Collection<StoredLibraryCount> PrevMovieLibraryCounts { get; set; }
 
     /// <summary>
-    /// Gets or sets the number of series these libraries held when the last newsletter was sent.
-    /// Null when no newsletter has been sent yet.
+    /// Gets or sets the per-library series and episode counts captured when the last newsletter
+    /// was sent. Empty until the first newsletter has been sent.
     /// </summary>
-    int? PrevSeriesCount { get; set; }
-
-    /// <summary>
-    /// Gets or sets the number of episodes these libraries held when the last newsletter was sent.
-    /// Null when no newsletter has been sent yet.
-    /// </summary>
-    int? PrevEpisodeCount { get; set; }
+    Collection<StoredLibraryCount> PrevSeriesLibraryCounts { get; set; }
 }

--- a/Jellyfin.Plugin.Newsletters/Configuration/ITemplatedConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/ITemplatedConfiguration.cs
@@ -1,6 +1,3 @@
-// Collection properties need setters so the plugin configuration can be XML-serialized,
-// the same reason PluginConfiguration suppresses these.
-#pragma warning disable CA2227
 using System.Collections.ObjectModel;
 using Jellyfin.Plugin.Newsletters.Shared.Models;
 
@@ -35,14 +32,14 @@ public interface ITemplatedConfiguration : INewsletterConfiguration
     string Header { get; }
 
     /// <summary>
-    /// Gets or sets the per-library movie counts captured when the last newsletter was sent.
+    /// Gets the per-library movie counts captured when the last newsletter was sent.
     /// Empty until the first newsletter has been sent.
     /// </summary>
-    Collection<StoredLibraryCount> PrevMovieLibraryCounts { get; set; }
+    Collection<StoredLibraryCount> PrevMovieLibraryCounts { get; }
 
     /// <summary>
-    /// Gets or sets the per-library series and episode counts captured when the last newsletter
+    /// Gets the per-library series and episode counts captured when the last newsletter
     /// was sent. Empty until the first newsletter has been sent.
     /// </summary>
-    Collection<StoredLibraryCount> PrevSeriesLibraryCounts { get; set; }
+    Collection<StoredLibraryCount> PrevSeriesLibraryCounts { get; }
 }

--- a/Jellyfin.Plugin.Newsletters/Configuration/ITemplatedConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/ITemplatedConfiguration.cs
@@ -27,4 +27,22 @@ public interface ITemplatedConfiguration : INewsletterConfiguration
     /// If empty, the default template file is used.
     /// </summary>
     string Header { get; }
+
+    /// <summary>
+    /// Gets or sets the number of movies these libraries held when the last newsletter was sent.
+    /// Null when no newsletter has been sent yet.
+    /// </summary>
+    int? PrevMovieCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of series these libraries held when the last newsletter was sent.
+    /// Null when no newsletter has been sent yet.
+    /// </summary>
+    int? PrevSeriesCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of episodes these libraries held when the last newsletter was sent.
+    /// Null when no newsletter has been sent yet.
+    /// </summary>
+    int? PrevEpisodeCount { get; set; }
 }

--- a/Jellyfin.Plugin.Newsletters/Configuration/MatrixConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/MatrixConfiguration.cs
@@ -1,5 +1,7 @@
 using System.Collections.ObjectModel;
 
+using Jellyfin.Plugin.Newsletters.Shared.Models;
+
 namespace Jellyfin.Plugin.Newsletters.Configuration;
 
 /// <summary>
@@ -101,17 +103,12 @@ public class MatrixConfiguration : ITemplatedConfiguration
     public int MaxItemsPerSection { get; set; } = 0;
 
     /// <summary>
-    /// Gets or sets the movie count captured when the last newsletter was sent.
+    /// Gets or sets the per-library movie counts captured when the last newsletter was sent.
     /// </summary>
-    public int? PrevMovieCount { get; set; }
+    public Collection<StoredLibraryCount> PrevMovieLibraryCounts { get; set; } = new Collection<StoredLibraryCount>();
 
     /// <summary>
-    /// Gets or sets the series count captured when the last newsletter was sent.
+    /// Gets or sets the per-library series and episode counts captured when the last newsletter was sent.
     /// </summary>
-    public int? PrevSeriesCount { get; set; }
-
-    /// <summary>
-    /// Gets or sets the episode count captured when the last newsletter was sent.
-    /// </summary>
-    public int? PrevEpisodeCount { get; set; }
+    public Collection<StoredLibraryCount> PrevSeriesLibraryCounts { get; set; } = new Collection<StoredLibraryCount>();
 }

--- a/Jellyfin.Plugin.Newsletters/Configuration/MatrixConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/MatrixConfiguration.cs
@@ -99,4 +99,19 @@ public class MatrixConfiguration : ITemplatedConfiguration
     /// A value of 0 means unlimited (default).
     /// </summary>
     public int MaxItemsPerSection { get; set; } = 0;
+
+    /// <summary>
+    /// Gets or sets the movie count captured when the last newsletter was sent.
+    /// </summary>
+    public int? PrevMovieCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the series count captured when the last newsletter was sent.
+    /// </summary>
+    public int? PrevSeriesCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the episode count captured when the last newsletter was sent.
+    /// </summary>
+    public int? PrevEpisodeCount { get; set; }
 }

--- a/Jellyfin.Plugin.Newsletters/Shared/LibraryStats.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/LibraryStats.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using Jellyfin.Data.Enums;
@@ -32,21 +33,22 @@ public static class LibraryStats
     private static readonly ConcurrentDictionary<string, CacheEntry> CountCache = new();
 
     /// <summary>
-    /// Gets the media counts for the libraries selected on a newsletter configuration.
+    /// Gets the per-library media counts for the libraries selected on a newsletter configuration.
     /// </summary>
     /// <param name="libraryManager">The Jellyfin library manager.</param>
     /// <param name="logger">The logger used to report lookup failures.</param>
     /// <param name="config">The configuration whose library selection should be counted.</param>
     /// <returns>
-    /// The counts, or null when the library could not be queried. A configuration with nothing
-    /// selected returns zeros rather than null, so callers can tell "empty" from "failed" - which
-    /// matters when the result is about to be stored as the baseline for the next newsletter.
+    /// The snapshot, or null when the library could not be walked. A configuration with nothing
+    /// selected returns an empty snapshot rather than null, so callers can tell "empty" from
+    /// "failed" - which matters when the result is about to be stored as the baseline for the
+    /// next newsletter.
     /// </returns>
-    public static LibraryCounts? GetCounts(ILibraryManager libraryManager, Logger logger, INewsletterConfiguration config)
+    internal static Snapshot? GetSnapshot(ILibraryManager libraryManager, Logger logger, INewsletterConfiguration config)
     {
         if (config is null)
         {
-            return new LibraryCounts(0, 0, 0);
+            return new Snapshot();
         }
 
         var movieLibraries = ParseIds(config.SelectedMoviesLibraries);
@@ -56,22 +58,23 @@ public static class LibraryStats
         if (CountCache.TryGetValue(cacheKey, out var cached) && DateTime.UtcNow - cached.CapturedAt < CacheLifetime)
         {
             logger.Debug($"Using cached library counts for key '{cacheKey}'");
-            return cached.Counts;
+            return cached.Snapshot;
         }
 
         logger.Debug($"Library selection for counts - Movies: [{string.Join(", ", movieLibraries)}], Series: [{string.Join(", ", seriesLibraries)}]");
 
-        var counts = Compute(libraryManager, logger, movieLibraries, seriesLibraries);
-        if (counts is null)
+        var snapshot = Compute(libraryManager, logger, movieLibraries, seriesLibraries);
+        if (snapshot is null)
         {
             // Not cached - a transient failure should not stick around for the TTL.
             return null;
         }
 
-        CountCache[cacheKey] = new CacheEntry(DateTime.UtcNow, counts);
+        CountCache[cacheKey] = new CacheEntry(DateTime.UtcNow, snapshot);
 
-        logger.Debug($"Library counts resolved - Movies: {counts.Movies}, Series: {counts.Series}, Episodes: {counts.Episodes}");
-        return counts;
+        var totals = snapshot.Totals;
+        logger.Debug($"Library counts resolved - Movies: {totals.Movies}, Series: {totals.Series}, Episodes: {totals.Episodes}");
+        return snapshot;
     }
 
     /// <summary>
@@ -82,7 +85,7 @@ public static class LibraryStats
         CountCache.Clear();
     }
 
-    private static LibraryCounts? Compute(ILibraryManager libraryManager, Logger logger, Guid[] movieLibraries, Guid[] seriesLibraries)
+    private static Snapshot? Compute(ILibraryManager libraryManager, Logger logger, Guid[] movieLibraries, Guid[] seriesLibraries)
     {
         // An empty selection counts as a legitimate zero, so say so plainly - otherwise a
         // configuration with no libraries picked looks identical to a broken lookup.
@@ -98,23 +101,30 @@ public static class LibraryStats
 
         try
         {
-            int movies = 0;
-            int series = 0;
-            int episodes = 0;
+            var snapshot = new Snapshot();
 
             foreach (var libraryId in movieLibraries)
             {
-                movies += CountInLibrary(libraryManager, logger, libraryId).Movies;
+                var counted = CountInLibrary(libraryManager, logger, libraryId);
+                snapshot.MovieLibraries.Add(new StoredLibraryCount
+                {
+                    LibraryId = libraryId.ToString("N", CultureInfo.InvariantCulture),
+                    Titles = counted.Movies
+                });
             }
 
             foreach (var libraryId in seriesLibraries)
             {
                 var counted = CountInLibrary(libraryManager, logger, libraryId);
-                series += counted.Series;
-                episodes += counted.Episodes;
+                snapshot.SeriesLibraries.Add(new StoredLibraryCount
+                {
+                    LibraryId = libraryId.ToString("N", CultureInfo.InvariantCulture),
+                    Titles = counted.Series,
+                    Episodes = counted.Episodes
+                });
             }
 
-            return new LibraryCounts(movies, series, episodes);
+            return snapshot;
         }
         catch (Exception ex)
         {
@@ -197,16 +207,93 @@ public static class LibraryStats
         return $"{movies}|{series}";
     }
 
+    /// <summary>
+    /// The per-library media counts for one newsletter configuration's library selection.
+    /// </summary>
+    /// <remarks>
+    /// Nested here because <see cref="LibraryStats"/> is the only thing that produces one; it is
+    /// the shape of a counting result rather than a domain model in its own right. Internal
+    /// because nothing outside this plugin consumes it.
+    /// </remarks>
+    internal sealed class Snapshot
+    {
+        /// <summary>
+        /// Gets the counts for each selected movie library.
+        /// </summary>
+        public Collection<StoredLibraryCount> MovieLibraries { get; } = new Collection<StoredLibraryCount>();
+
+        /// <summary>
+        /// Gets the counts for each selected series library.
+        /// </summary>
+        public Collection<StoredLibraryCount> SeriesLibraries { get; } = new Collection<StoredLibraryCount>();
+
+        /// <summary>
+        /// Gets the combined totals across every selected library.
+        /// </summary>
+        public LibraryCounts Totals => new LibraryCounts(
+            MovieLibraries.Sum(l => l.Titles),
+            SeriesLibraries.Sum(l => l.Titles),
+            SeriesLibraries.Sum(l => l.Episodes));
+
+        /// <summary>
+        /// Gets the change between a stored baseline and this snapshot.
+        /// </summary>
+        /// <remarks>
+        /// Only libraries present on both sides are compared. A library added to the selection
+        /// since the baseline was taken has nothing to compare against, and a library removed from
+        /// the selection is no longer in this snapshot - so neither can pass a change in scope off
+        /// as a change in the library. The totals still reflect the full current selection; only
+        /// the change is restricted.
+        /// </remarks>
+        /// <param name="previousMovieLibraries">The stored per-library movie counts.</param>
+        /// <param name="previousSeriesLibraries">The stored per-library series and episode counts.</param>
+        /// <returns>The change, as movie, series and episode deltas.</returns>
+        public LibraryCounts DeltaFrom(
+            Collection<StoredLibraryCount>? previousMovieLibraries,
+            Collection<StoredLibraryCount>? previousSeriesLibraries)
+        {
+            int movies = 0;
+            int series = 0;
+            int episodes = 0;
+
+            foreach (var current in MovieLibraries)
+            {
+                var previous = Find(previousMovieLibraries, current.LibraryId);
+                if (previous is not null)
+                {
+                    movies += current.Titles - previous.Titles;
+                }
+            }
+
+            foreach (var current in SeriesLibraries)
+            {
+                var previous = Find(previousSeriesLibraries, current.LibraryId);
+                if (previous is not null)
+                {
+                    series += current.Titles - previous.Titles;
+                    episodes += current.Episodes - previous.Episodes;
+                }
+            }
+
+            return new LibraryCounts(movies, series, episodes);
+        }
+
+        private static StoredLibraryCount? Find(Collection<StoredLibraryCount>? stored, string libraryId)
+        {
+            return stored?.FirstOrDefault(l => string.Equals(l.LibraryId, libraryId, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
     private sealed class CacheEntry
     {
-        public CacheEntry(DateTime capturedAt, LibraryCounts counts)
+        public CacheEntry(DateTime capturedAt, Snapshot snapshot)
         {
             CapturedAt = capturedAt;
-            Counts = counts;
+            Snapshot = snapshot;
         }
 
         public DateTime CapturedAt { get; }
 
-        public LibraryCounts Counts { get; }
+        public Snapshot Snapshot { get; }
     }
 }

--- a/Jellyfin.Plugin.Newsletters/Shared/LibraryStats.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/LibraryStats.cs
@@ -7,6 +7,8 @@ using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.Newsletters.Configuration;
 using Jellyfin.Plugin.Newsletters.Shared.Models;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 
 namespace Jellyfin.Plugin.Newsletters.Shared;
@@ -57,6 +59,8 @@ public static class LibraryStats
             return cached.Counts;
         }
 
+        logger.Debug($"Library selection for counts - Movies: [{string.Join(", ", movieLibraries)}], Series: [{string.Join(", ", seriesLibraries)}]");
+
         var counts = Compute(libraryManager, logger, movieLibraries, seriesLibraries);
         if (counts is null)
         {
@@ -80,11 +84,35 @@ public static class LibraryStats
 
     private static LibraryCounts? Compute(ILibraryManager libraryManager, Logger logger, Guid[] movieLibraries, Guid[] seriesLibraries)
     {
+        // An empty selection counts as a legitimate zero, so say so plainly - otherwise a
+        // configuration with no libraries picked looks identical to a broken lookup.
+        if (movieLibraries.Length == 0)
+        {
+            logger.Warn("No movie libraries are selected on this configuration - the movie count will be 0.");
+        }
+
+        if (seriesLibraries.Length == 0)
+        {
+            logger.Warn("No series libraries are selected on this configuration - the series and episode counts will be 0.");
+        }
+
         try
         {
-            int movies = Count(libraryManager, BaseItemKind.Movie, movieLibraries);
-            int series = Count(libraryManager, BaseItemKind.Series, seriesLibraries);
-            int episodes = Count(libraryManager, BaseItemKind.Episode, seriesLibraries);
+            int movies = 0;
+            int series = 0;
+            int episodes = 0;
+
+            foreach (var libraryId in movieLibraries)
+            {
+                movies += CountInLibrary(libraryManager, logger, libraryId).Movies;
+            }
+
+            foreach (var libraryId in seriesLibraries)
+            {
+                var counted = CountInLibrary(libraryManager, logger, libraryId);
+                series += counted.Series;
+                episodes += counted.Episodes;
+            }
 
             return new LibraryCounts(movies, series, episodes);
         }
@@ -95,25 +123,52 @@ public static class LibraryStats
         }
     }
 
-    private static int Count(ILibraryManager libraryManager, BaseItemKind kind, Guid[] libraryIds)
+    /// <summary>
+    /// Counts the media in one library by walking its children.
+    /// </summary>
+    /// <remarks>
+    /// The hierarchy is walked rather than queried. An <see cref="InternalItemsQuery"/> scoped by
+    /// ParentId or TopParentIds returns nothing for a library's collection-folder ID, so the
+    /// filter column does not hold what the configuration stores. Walking the folder counts what
+    /// is actually there, and one pass yields all three totals.
+    /// </remarks>
+    private static (int Movies, int Series, int Episodes) CountInLibrary(ILibraryManager libraryManager, Logger logger, Guid libraryId)
     {
-        if (libraryIds.Length == 0)
+        if (libraryManager.GetItemById(libraryId) is not Folder folder)
         {
-            return 0;
+            logger.Warn($"Library {libraryId:N} did not resolve to a folder - skipping it in the counts.");
+            return (0, 0, 0);
         }
 
-        var query = new InternalItemsQuery
-        {
-            IncludeItemTypes = new[] { kind },
-            TopParentIds = libraryIds,
-            Recursive = true,
-            // Excludes episodes Jellyfin knows about but has no file for (missing/unaired).
-            IsVirtualItem = false,
-            Limit = 0,
-            EnableTotalRecordCount = true
-        };
+        int movies = 0;
+        int series = 0;
+        int episodes = 0;
 
-        return libraryManager.GetItemsResult(query).TotalRecordCount;
+        foreach (var child in folder.GetRecursiveChildren())
+        {
+            // Excludes episodes Jellyfin knows about but has no file for (missing/unaired).
+            if (child.IsVirtualItem)
+            {
+                continue;
+            }
+
+            switch (child)
+            {
+                case Movie:
+                    movies++;
+                    break;
+                case Series:
+                    series++;
+                    break;
+                case Episode:
+                    episodes++;
+                    break;
+            }
+        }
+
+        logger.Debug($"Library '{folder.Name}' ({libraryId:N}) - Movies: {movies}, Series: {series}, Episodes: {episodes}");
+
+        return (movies, series, episodes);
     }
 
     private static Guid[] ParseIds(IEnumerable<string>? libraryIds)

--- a/Jellyfin.Plugin.Newsletters/Shared/LibraryStats.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/LibraryStats.cs
@@ -8,8 +8,6 @@ using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.Newsletters.Configuration;
 using Jellyfin.Plugin.Newsletters.Shared.Models;
 using MediaBrowser.Controller.Entities;
-using MediaBrowser.Controller.Entities.Movies;
-using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 
 namespace Jellyfin.Plugin.Newsletters.Shared;
@@ -106,21 +104,33 @@ public static class LibraryStats
             foreach (var libraryId in movieLibraries)
             {
                 var counted = CountInLibrary(libraryManager, logger, libraryId);
+                if (counted is null)
+                {
+                    // Abandon the whole snapshot rather than report a partial one. A partial
+                    // result would be stored as the baseline and fake a huge delta next cycle.
+                    return null;
+                }
+
                 snapshot.MovieLibraries.Add(new StoredLibraryCount
                 {
                     LibraryId = libraryId.ToString("N", CultureInfo.InvariantCulture),
-                    Titles = counted.Movies
+                    Titles = counted.Value.Movies
                 });
             }
 
             foreach (var libraryId in seriesLibraries)
             {
                 var counted = CountInLibrary(libraryManager, logger, libraryId);
+                if (counted is null)
+                {
+                    return null;
+                }
+
                 snapshot.SeriesLibraries.Add(new StoredLibraryCount
                 {
                     LibraryId = libraryId.ToString("N", CultureInfo.InvariantCulture),
-                    Titles = counted.Series,
-                    Episodes = counted.Episodes
+                    Titles = counted.Value.Series,
+                    Episodes = counted.Value.Episodes
                 });
             }
 
@@ -134,51 +144,56 @@ public static class LibraryStats
     }
 
     /// <summary>
-    /// Counts the media in one library by walking its children.
+    /// Counts the media in one library.
     /// </summary>
     /// <remarks>
-    /// The hierarchy is walked rather than queried. An <see cref="InternalItemsQuery"/> scoped by
-    /// ParentId or TopParentIds returns nothing for a library's collection-folder ID, so the
-    /// filter column does not hold what the configuration stores. Walking the folder counts what
-    /// is actually there, and one pass yields all three totals.
+    /// Counted through the resolved <see cref="Folder"/> rather than through
+    /// <see cref="ILibraryManager"/>. The manager queries the item repository directly, which
+    /// filters on raw columns - scoping by ParentId or TopParentIds there returns nothing for a
+    /// library's collection-folder ID, which is what the configuration stores. Folder applies the
+    /// parent-scope translation first, so it resolves the same ID the way browsing a library does.
     /// </remarks>
-    private static (int Movies, int Series, int Episodes) CountInLibrary(ILibraryManager libraryManager, Logger logger, Guid libraryId)
+    private static (int Movies, int Series, int Episodes)? CountInLibrary(ILibraryManager libraryManager, Logger logger, Guid libraryId)
     {
         if (libraryManager.GetItemById(libraryId) is not Folder folder)
         {
-            logger.Warn($"Library {libraryId:N} did not resolve to a folder - skipping it in the counts.");
-            return (0, 0, 0);
+            // Null rather than zeros: a library that is mid-rescan, unmounted, or not yet loaded
+            // after a restart must not be recorded as empty, or the next newsletter would report
+            // everything in it as newly added.
+            logger.Warn($"Library {libraryId:N} did not resolve to a folder - counts are unavailable this cycle.");
+            return null;
         }
 
-        int movies = 0;
-        int series = 0;
-        int episodes = 0;
-
-        foreach (var child in folder.GetRecursiveChildren())
-        {
-            // Excludes episodes Jellyfin knows about but has no file for (missing/unaired).
-            if (child.IsVirtualItem)
-            {
-                continue;
-            }
-
-            switch (child)
-            {
-                case Movie:
-                    movies++;
-                    break;
-                case Series:
-                    series++;
-                    break;
-                case Episode:
-                    episodes++;
-                    break;
-            }
-        }
+        int movies = CountOfKind(folder, BaseItemKind.Movie);
+        int series = CountOfKind(folder, BaseItemKind.Series);
+        int episodes = CountOfKind(folder, BaseItemKind.Episode);
 
         logger.Debug($"Library '{folder.Name}' ({libraryId:N}) - Movies: {movies}, Series: {series}, Episodes: {episodes}");
 
         return (movies, series, episodes);
+    }
+
+    /// <summary>
+    /// Counts items of one type in a library without loading them.
+    /// </summary>
+    /// <param name="folder">The resolved library folder.</param>
+    /// <param name="kind">The item type to count.</param>
+    /// <returns>The number of matching items.</returns>
+    private static int CountOfKind(Folder folder, BaseItemKind kind)
+    {
+        // Limit 0 with the total record count enabled counts in the database and returns no rows,
+        // so a large library costs one integer rather than an object per item.
+        var query = new InternalItemsQuery
+        {
+            IncludeItemTypes = new[] { kind },
+            Recursive = true,
+            // Excludes episodes Jellyfin knows about but has no file for (missing/unaired).
+            IsVirtualItem = false,
+            Limit = 0,
+            EnableTotalRecordCount = true
+        };
+
+        return folder.GetItems(query).TotalRecordCount;
     }
 
     private static Guid[] ParseIds(IEnumerable<string>? libraryIds)

--- a/Jellyfin.Plugin.Newsletters/Shared/LibraryStats.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/LibraryStats.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.Newsletters.Configuration;
+using Jellyfin.Plugin.Newsletters.Shared.Models;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.Newsletters.Shared;
+
+/// <summary>
+/// Counts the media a newsletter configuration's selected libraries hold.
+/// </summary>
+/// <remarks>
+/// Every client configuration carries its own library selection, so counts are resolved per
+/// configuration rather than server-wide. Results are cached by the selected library IDs, which
+/// means two configurations covering the same libraries share one query while a configuration
+/// covering different libraries gets its own numbers.
+/// </remarks>
+public static class LibraryStats
+{
+    // One send builds a message per client configuration, and each build asks for counts.
+    // A short TTL keeps those consistent with each other without pinning a stale value across
+    // a week of test sends.
+    private static readonly TimeSpan CacheLifetime = TimeSpan.FromMinutes(5);
+
+    private static readonly ConcurrentDictionary<string, CacheEntry> CountCache = new();
+
+    /// <summary>
+    /// Gets the media counts for the libraries selected on a newsletter configuration.
+    /// </summary>
+    /// <param name="libraryManager">The Jellyfin library manager.</param>
+    /// <param name="logger">The logger used to report lookup failures.</param>
+    /// <param name="config">The configuration whose library selection should be counted.</param>
+    /// <returns>
+    /// The counts, or null when the library could not be queried. A configuration with nothing
+    /// selected returns zeros rather than null, so callers can tell "empty" from "failed" - which
+    /// matters when the result is about to be stored as the baseline for the next newsletter.
+    /// </returns>
+    public static LibraryCounts? GetCounts(ILibraryManager libraryManager, Logger logger, INewsletterConfiguration config)
+    {
+        if (config is null)
+        {
+            return new LibraryCounts(0, 0, 0);
+        }
+
+        var movieLibraries = ParseIds(config.SelectedMoviesLibraries);
+        var seriesLibraries = ParseIds(config.SelectedSeriesLibraries);
+        string cacheKey = BuildCacheKey(movieLibraries, seriesLibraries);
+
+        if (CountCache.TryGetValue(cacheKey, out var cached) && DateTime.UtcNow - cached.CapturedAt < CacheLifetime)
+        {
+            logger.Debug($"Using cached library counts for key '{cacheKey}'");
+            return cached.Counts;
+        }
+
+        var counts = Compute(libraryManager, logger, movieLibraries, seriesLibraries);
+        if (counts is null)
+        {
+            // Not cached - a transient failure should not stick around for the TTL.
+            return null;
+        }
+
+        CountCache[cacheKey] = new CacheEntry(DateTime.UtcNow, counts);
+
+        logger.Debug($"Library counts resolved - Movies: {counts.Movies}, Series: {counts.Series}, Episodes: {counts.Episodes}");
+        return counts;
+    }
+
+    /// <summary>
+    /// Drops every cached count so the next request re-queries the library.
+    /// </summary>
+    public static void ClearCache()
+    {
+        CountCache.Clear();
+    }
+
+    private static LibraryCounts? Compute(ILibraryManager libraryManager, Logger logger, Guid[] movieLibraries, Guid[] seriesLibraries)
+    {
+        try
+        {
+            int movies = Count(libraryManager, BaseItemKind.Movie, movieLibraries);
+            int series = Count(libraryManager, BaseItemKind.Series, seriesLibraries);
+            int episodes = Count(libraryManager, BaseItemKind.Episode, seriesLibraries);
+
+            return new LibraryCounts(movies, series, episodes);
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"Error counting library items: {ex.Message}");
+            return null;
+        }
+    }
+
+    private static int Count(ILibraryManager libraryManager, BaseItemKind kind, Guid[] libraryIds)
+    {
+        if (libraryIds.Length == 0)
+        {
+            return 0;
+        }
+
+        var query = new InternalItemsQuery
+        {
+            IncludeItemTypes = new[] { kind },
+            TopParentIds = libraryIds,
+            Recursive = true,
+            // Excludes episodes Jellyfin knows about but has no file for (missing/unaired).
+            IsVirtualItem = false,
+            Limit = 0,
+            EnableTotalRecordCount = true
+        };
+
+        return libraryManager.GetItemsResult(query).TotalRecordCount;
+    }
+
+    private static Guid[] ParseIds(IEnumerable<string>? libraryIds)
+    {
+        var parsedIds = new List<Guid>();
+
+        foreach (var rawId in libraryIds ?? Enumerable.Empty<string>())
+        {
+            // Skipped rather than thrown on: one malformed entry should not wipe out the
+            // counts for the whole configuration. TryParse already rejects null and blanks.
+            if (Guid.TryParse(rawId, out var parsed))
+            {
+                parsedIds.Add(parsed);
+            }
+        }
+
+        return parsedIds.ToArray();
+    }
+
+    private static string BuildCacheKey(Guid[] movieLibraries, Guid[] seriesLibraries)
+    {
+        // Sorted so that the same selection in a different order hits the same entry.
+        string movies = string.Join(",", movieLibraries.Select(id => id.ToString("N", CultureInfo.InvariantCulture)).OrderBy(id => id, StringComparer.Ordinal));
+        string series = string.Join(",", seriesLibraries.Select(id => id.ToString("N", CultureInfo.InvariantCulture)).OrderBy(id => id, StringComparer.Ordinal));
+
+        return $"{movies}|{series}";
+    }
+
+    private sealed class CacheEntry
+    {
+        public CacheEntry(DateTime capturedAt, LibraryCounts counts)
+        {
+            CapturedAt = capturedAt;
+            Counts = counts;
+        }
+
+        public DateTime CapturedAt { get; }
+
+        public LibraryCounts Counts { get; }
+    }
+}

--- a/Jellyfin.Plugin.Newsletters/Shared/Models/LibraryCounts.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/Models/LibraryCounts.cs
@@ -1,0 +1,41 @@
+namespace Jellyfin.Plugin.Newsletters.Shared.Models;
+
+/// <summary>
+/// A snapshot of how many media items a set of libraries holds.
+/// </summary>
+public sealed class LibraryCounts
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LibraryCounts"/> class.
+    /// </summary>
+    /// <param name="movies">The number of movies.</param>
+    /// <param name="series">The number of series.</param>
+    /// <param name="episodes">The number of episodes.</param>
+    public LibraryCounts(int movies, int series, int episodes)
+    {
+        Movies = movies;
+        Series = series;
+        Episodes = episodes;
+    }
+
+    /// <summary>
+    /// Gets the number of movies.
+    /// </summary>
+    public int Movies { get; }
+
+    /// <summary>
+    /// Gets the number of series.
+    /// </summary>
+    public int Series { get; }
+
+    /// <summary>
+    /// Gets the number of episodes.
+    /// </summary>
+    public int Episodes { get; }
+
+    /// <summary>
+    /// Gets the number of playable items: movies plus episodes.
+    /// Series are containers rather than playable media, so they are deliberately excluded.
+    /// </summary>
+    public int Items => Movies + Episodes;
+}

--- a/Jellyfin.Plugin.Newsletters/Shared/Models/LibraryCounts.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/Models/LibraryCounts.cs
@@ -1,8 +1,12 @@
 namespace Jellyfin.Plugin.Newsletters.Shared.Models;
 
 /// <summary>
-/// A snapshot of how many media items a set of libraries holds.
+/// The combined media totals for a set of libraries, as rendered into a newsletter.
 /// </summary>
+/// <remarks>
+/// A computed value, never persisted. The counts remembered between newsletters are stored per
+/// library as <see cref="StoredLibraryCount"/>.
+/// </remarks>
 public sealed class LibraryCounts
 {
     /// <summary>

--- a/Jellyfin.Plugin.Newsletters/Shared/Models/LibraryCounts.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/Models/LibraryCounts.cs
@@ -38,4 +38,14 @@ public sealed class LibraryCounts
     /// Series are containers rather than playable media, so they are deliberately excluded.
     /// </summary>
     public int Items => Movies + Episodes;
+
+    /// <summary>
+    /// Gets a sample set of counts for test newsletters, where real library totals are not
+    /// meaningful. Paired with a zero baseline so every delta renders as "+1".
+    /// </summary>
+    /// <returns>A sample <see cref="LibraryCounts"/> holding one of each item type.</returns>
+    public static LibraryCounts GetTestObj()
+    {
+        return new LibraryCounts(1, 1, 1);
+    }
 }

--- a/Jellyfin.Plugin.Newsletters/Shared/Models/StoredLibraryCount.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/Models/StoredLibraryCount.cs
@@ -1,0 +1,31 @@
+namespace Jellyfin.Plugin.Newsletters.Shared.Models;
+
+/// <summary>
+/// How much media a single library held when the last newsletter was sent.
+/// </summary>
+/// <remarks>
+/// Counts are stored per library rather than as one total so that changing a configuration's
+/// library selection cannot fake a delta. A library that was added or removed since the last
+/// newsletter simply has no counterpart to compare against, and is left out of the change.
+/// A library is either a movie library or a series library - never both - so only the counts
+/// that library can contribute are meaningful.
+/// </remarks>
+public sealed class StoredLibraryCount
+{
+    /// <summary>
+    /// Gets or sets the Jellyfin library (virtual folder) ID this snapshot describes.
+    /// </summary>
+    public string LibraryId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the number of titles the library held: movies for a movie library,
+    /// series for a series library.
+    /// </summary>
+    public int Titles { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of episodes the library held. Only meaningful for a series
+    /// library; a movie library holds no episodes.
+    /// </summary>
+    public int Episodes { get; set; }
+}

--- a/Jellyfin.Plugin.Newsletters/Templates/Classic/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Classic/template_body.html
@@ -16,6 +16,27 @@
 								</h1>
 								<h3 id="Date" style="color:#FFFFFF;margin:0px;">{prevd} {prevmon} {prevyyyy} - {d} {mon}
 									{yyyy}</h3>
+								<table id="Stats" align="center" cellpadding="0" cellspacing="0" bgcolor="#151515"
+									style="margin:14px auto 0 auto;border-spacing:0;background:#151515;border:1px solid #242424;border-radius:10px;">
+									<tr>
+										<td style="text-align:center;padding:16px 24px 2px 24px;font-size:26px;font-weight:bold;color:#FFFFFF;line-height:1.2;">{MovieCount}</td>
+										<td style="text-align:center;padding:16px 24px 2px 24px;font-size:26px;font-weight:bold;color:#FFFFFF;line-height:1.2;">{SeriesCount}</td>
+										<td style="text-align:center;padding:16px 24px 2px 24px;font-size:26px;font-weight:bold;color:#FFFFFF;line-height:1.2;">{EpisodeCount}</td>
+									</tr>
+									<tr>
+										<td style="text-align:center;padding:0 24px 2px 24px;font-size:10px;letter-spacing:1.6px;text-transform:uppercase;color:#9A9A9A;">Movies</td>
+										<td style="text-align:center;padding:0 24px 2px 24px;font-size:10px;letter-spacing:1.6px;text-transform:uppercase;color:#9A9A9A;">Series</td>
+										<td style="text-align:center;padding:0 24px 2px 24px;font-size:10px;letter-spacing:1.6px;text-transform:uppercase;color:#9A9A9A;">Episodes</td>
+									</tr>
+									<tr>
+										<td style="text-align:center;padding:0 24px;font-size:13px;font-weight:bold;color:#C8C8C8;">{newMovieCount}</td>
+										<td style="text-align:center;padding:0 24px;font-size:13px;font-weight:bold;color:#C8C8C8;">{newSeriesCount}</td>
+										<td style="text-align:center;padding:0 24px;font-size:13px;font-weight:bold;color:#C8C8C8;">{newEpisodeCount}</td>
+									</tr>
+									<tr>
+										<td colspan="3" style="text-align:center;padding:6px 24px 14px 24px;font-size:10px;letter-spacing:1.2px;text-transform:uppercase;color:#6A6A6A;">since the last newsletter</td>
+									</tr>
+								</table>
 							</td>
 						</tr>
 						<tr>

--- a/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_body.html
@@ -3,5 +3,7 @@
 </h1>
 <small>
     <font data-mx-color="#a0a0a0">{prevd} {prevmon} {prevyyyy} - {d} {mon} {yyyy}</font>
+    <br>
+    <font data-mx-color="#c0c0c0">Movies: {MovieCount} ({newMovieCount}) &bull; Series: {SeriesCount} ({newSeriesCount}) &bull; Episodes: {EpisodeCount} ({newEpisodeCount})</font>
 </small>
 {EntryData}

--- a/Jellyfin.Plugin.Newsletters/Templates/Modern/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Modern/template_body.html
@@ -76,6 +76,49 @@
 			letter-spacing: 1px;
 		}
 
+		.header-stats {
+			margin: 18px auto 0 auto;
+			border-spacing: 0;
+			background-color: #1a1a1a;
+			border-radius: 12px;
+			box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+		}
+
+		.header-stats td {
+			text-align: center;
+		}
+
+		.header-stats .stat-value {
+			padding: 16px 24px 2px 24px;
+			font-size: 26px;
+			font-weight: bold;
+			color: #ffffff;
+			line-height: 1.2;
+		}
+
+		.header-stats .stat-label {
+			padding: 0 24px 2px 24px;
+			font-size: 10px;
+			letter-spacing: 1.6px;
+			text-transform: uppercase;
+			color: #9a9a9a;
+		}
+
+		.header-stats .stat-delta {
+			padding: 0 24px;
+			font-size: 13px;
+			font-weight: bold;
+			color: #c8c8c8;
+		}
+
+		.header-stats .stat-caption {
+			padding: 6px 24px 14px 24px;
+			font-size: 10px;
+			letter-spacing: 1.2px;
+			text-transform: uppercase;
+			color: #6a6a6a;
+		}
+
 		.card-row {
 			padding: 0 10px 20px 10px;
 		}
@@ -181,6 +224,27 @@
 						</a>
 					</h1>
 					<div class="header-date">{prevd} {prevmon} {prevyyyy} - {d} {mon} {yyyy}</div>
+					<table class="header-stats" role="presentation" align="center" cellpadding="0" cellspacing="0"
+						bgcolor="#1a1a1a">
+						<tr>
+							<td class="stat-value">{MovieCount}</td>
+							<td class="stat-value">{SeriesCount}</td>
+							<td class="stat-value">{EpisodeCount}</td>
+						</tr>
+						<tr>
+							<td class="stat-label">Movies</td>
+							<td class="stat-label">Series</td>
+							<td class="stat-label">Episodes</td>
+						</tr>
+						<tr>
+							<td class="stat-delta">{newMovieCount}</td>
+							<td class="stat-delta">{newSeriesCount}</td>
+							<td class="stat-delta">{newEpisodeCount}</td>
+						</tr>
+						<tr>
+							<td class="stat-caption" colspan="3">since the last newsletter</td>
+						</tr>
+					</table>
 				</td>
 			</tr>
 

--- a/README.md
+++ b/README.md
@@ -533,6 +533,52 @@ Some of these may not interest that average user (if anyone), but I figured I wo
 ```
 </details>
 
+<details>
+<summary><b>Library Count Tags (Click to expand)</b></summary>
+
+Counts cover only the libraries selected on the configuration that is sending the newsletter, so two configurations pointed at different libraries will legitimately show different numbers.
+
+Current library size:
+
+```
+- {MovieCount} - Number of movies (e.g. 14)
+- {SeriesCount} - Number of series (e.g. 7)
+- {EpisodeCount} - Number of episodes (e.g. 213)
+- {ItemCount} - Movies plus episodes (series are containers, so they are not counted here)
+```
+
+Library size when the previous newsletter was sent:
+
+```
+- {prevMovieCount} - Number of movies at the previous newsletter
+- {prevSeriesCount} - Number of series at the previous newsletter
+- {prevEpisodeCount} - Number of episodes at the previous newsletter
+- {prevItemCount} - Movies plus episodes at the previous newsletter
+```
+
+Change since the previous newsletter. **These always render with a sign** - `+2` when items were
+added, `-3` when items were deleted, `0` when nothing changed:
+
+```
+- {newMovieCount} - Change in movie count (e.g. +2)
+- {newSeriesCount} - Change in series count (e.g. +1)
+- {newEpisodeCount} - Change in episode count (e.g. -3)
+- {newItemCount} - Change in movies plus episodes
+```
+
+**Do not put your own `+` in front of these tags.** The sign is already included, so a hardcoded
+plus would read as `+-3` once media is deleted. Example usage:
+
+```
+Now with {MovieCount} movies and {SeriesCount} shows! ({newMovieCount} since last newsletter!)
+```
+
+On the very first newsletter there is nothing to compare against, so the `{prev*}` tags equal the
+current counts and every `{new*}` tag reads `0`. The comparison becomes meaningful from the second
+newsletter onwards.
+
+</details>
+
 ```
 - {ServerURL} - The configured server URL for Jellyfin
 - {SeasonEpsInfo} - This tag is the Plugin-generated Season/Episode data


### PR DESCRIPTION
Closes #82

## What

Adds 12 template tags exposing library size to Email and Matrix newsletters, plus a stats panel in the three default templates.

**Current totals**
`{MovieCount}` `{SeriesCount}` `{EpisodeCount}` `{ItemCount}`

**Totals at the previous newsletter**
`{prevMovieCount}` `{prevSeriesCount}` `{prevEpisodeCount}` `{prevItemCount}`

**Change since the previous newsletter — always signed (`+2` / `-3` / `0`)**
`{newMovieCount}` `{newSeriesCount}` `{newEpisodeCount}` `{newItemCount}`

## Why

Issue #82 asked for a way to write lines like *"Now with 14 movies and 7 shows! (+2 since last newsletter!)"*. Previously the only "since last time" data a template could reach was the date family (`{prevd}`, `{prevmon}`, …). The issue specifically called out that deletions must render correctly, so the `{new*}` tags always carry their own sign — a template must never hardcode a `+`, which would read as `+-3` after a deletion.

## How it works

Counts are **per client configuration**, scoped to that config's own `SelectedMoviesLibraries` / `SelectedSeriesLibraries`, so two configs pointed at different libraries legitimately show different numbers.

There is no "library growth" API, so the delta is remembered rather than computed:

- **Render time** — count the selected libraries, compare against the stored baseline.
- **Archive time** (`CopyNewsletterDataToArchive`, where `LastPublishedDate` is already stamped) — store the current counts as the next baseline.

Counts are cached for 5 minutes, keyed by the library-ID set, so several configs in one send share one lookup.

## Notes for reviewers

**Counting goes through `Folder`, not `ILibraryManager`.** `folder.GetItems(query)` with `Limit = 0` and `EnableTotalRecordCount = true` counts in the database and returns no rows, so a large library costs one integer rather than an object per item. The layer matters: `ILibraryManager.GetItemIds` / `GetItemsResult` query the item repository directly and filter on raw columns — scoped by `TopParentIds` or `ParentId` they return **0** for a library's collection-folder ID, which is the ID `SelectedMoviesLibraries` stores (the same value `Scraper.GetLibraryId` derives by path match). Both were tried against a real library and both returned zero. `Folder` applies the parent-scope translation first, which is the step the manager-level calls skip. The library folder itself is still resolved with `GetItemById`.

**A library that fails to resolve yields `null`, not zeros.** `CountInLibrary` returns `null` when `GetItemById` does not resolve, and `Compute` abandons the whole snapshot rather than returning a partial one. Without this, a library that is mid-rescan, unmounted, or not yet loaded after a restart would be recorded as empty, and the following newsletter would report every item in it as newly added (`176 - 0 = +176`). Rendering still falls back to zeros so the email never ships raw `{MovieCount}` tags, but that fallback is never persisted. An empty library *selection* remains a genuine zero and is logged as such.

**The baseline is stored per library, not as one total.** With a single total, adding a library to a config's selection would render as though every item in it had just been added (`+340` rather than `+2`). `StoredLibraryCount` records each library separately, and `Snapshot.DeltaFrom` only compares libraries present on both sides. Totals still reflect the full current selection; only the change is restricted. Removing a library, and a library deleted in Jellyfin, are handled the same way.

**`{prev*}` is derived (`current - delta`), not stored.** When a library joins the selection its items are in the totals but excluded from the delta, so a stored `prev` would break `prev + new == current` in a header that prints all three side by side.

**Configs never share baseline collections.** Configurations with the same library selection share one cached snapshot, so the stored rows are copied per config rather than assigned by reference.

**Test sends use sample counts** (1 / 1 / 1 against a zero baseline, so every delta reads `+1`), following the existing `JsonFileObj.GetTestObj()` convention. Real library totals would sit oddly beside the sample entries a test newsletter is built from.

**Scope:** Email and Matrix only (`ITemplatedConfiguration`). Discord and Telegram build embeds with no body template.

**Default templates:** Modern and Classic get a stats panel matching the existing `.card` styling; Matrix keeps a single-line fallback since it strips `class` and most styling. Existing installs keep their saved `Config.Body`, so this reaches fresh installs or anyone who clears that field.

## Testing

Verified on a live server:

- Counts match the library, scoped correctly per library with no cross-library bleed (176 movies / 49 series / 1536 episodes).
- Per-configuration independence across four Email and Matrix configs, including one with no movie libraries selected.
- Negative deltas — deletions render as `-N`, not `+-N`.
- Test sends in Modern and Classic.

Builds clean: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)