### PR TITLE
Add configurable newsletter title for Email and Matrix clients

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/HtmlContentBuilder.cs
@@ -172,7 +172,7 @@ public abstract class HtmlContentBuilder(
     }
 
     /// <summary>
-    /// Replaces the {ServerURL}, date, and library-count placeholders in a fully built newsletter body.
+    /// Replaces the {NewsletterTitle}, {ServerURL}, date, and library-count placeholders in a fully built newsletter body.
     /// </summary>
     /// <param name="html">The built newsletter body.</param>
     /// <param name="config">The configuration the newsletter is being rendered for.</param>
@@ -180,6 +180,7 @@ public abstract class HtmlContentBuilder(
     /// <returns>The body with every body-level placeholder resolved.</returns>
     public string ReplaceBodyPlaceholders(string html, ITemplatedConfiguration config, bool isTest = false)
     {
+        html = this.TemplateReplace(html, "{NewsletterTitle}", string.IsNullOrWhiteSpace(config.NewsletterTitle) ? "Jellyfin Newsletter" : config.NewsletterTitle);
         html = this.TemplateReplace(html, "{ServerURL}", Config.Hostname);
         html = ReplaceDatePlaceholders(html);
         return ReplaceStatPlaceholders(html, config, isTest);

--- a/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixClient.cs
+++ b/Jellyfin.Plugin.Newsletters/Clients/Matrix/MatrixClient.cs
@@ -217,7 +217,7 @@ public class MatrixClient(IServerApplicationHost appHost,
             var payload = new MatrixPayload
             {
                 MsgType = "m.text",
-                Body = "Jellyfin Newsletter (This message requires a Matrix client with HTML support to display correctly.)",
+                Body = $"{(string.IsNullOrWhiteSpace(matrixConfig.NewsletterTitle) ? "Jellyfin Newsletter" : matrixConfig.NewsletterTitle)} (This message requires a Matrix client with HTML support to display correctly.)",
                 Format = "org.matrix.custom.html",
                 FormattedBody = htmlBody
             };

--- a/Jellyfin.Plugin.Newsletters/Configuration/EmailConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/EmailConfiguration.cs
@@ -66,6 +66,11 @@ public class EmailConfiguration : ITemplatedConfiguration
     public string Subject { get; set; } = "Jellyfin Newsletter";
 
     /// <summary>
+    /// Gets or sets the newsletter title shown in the body template header, exposed as the {NewsletterTitle} tag.
+    /// </summary>
+    public string NewsletterTitle { get; set; } = "Jellyfin Newsletter";
+
+    /// <summary>
     /// Gets or sets the email body HTML template.
     /// </summary>
     public string Body { get; set; } = string.Empty;

--- a/Jellyfin.Plugin.Newsletters/Configuration/ITemplatedConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/ITemplatedConfiguration.cs
@@ -25,6 +25,11 @@ public interface ITemplatedConfiguration : INewsletterConfiguration
     string TemplateCategory { get; }
 
     /// <summary>
+    /// Gets the newsletter title shown in the body template header, exposed as the {NewsletterTitle} tag.
+    /// </summary>
+    string NewsletterTitle { get; }
+
+    /// <summary>
     /// Gets the custom HTML header template containing section headers for each event type.
     /// Uses template tags with IDs (header-add, header-update, header-delete, header-upcoming).
     /// If empty, the default template file is used.

--- a/Jellyfin.Plugin.Newsletters/Configuration/MatrixConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/MatrixConfiguration.cs
@@ -45,6 +45,11 @@ public class MatrixConfiguration : ITemplatedConfiguration
     public string TemplateCategory { get; set; } = "Matrix";
 
     /// <summary>
+    /// Gets or sets the newsletter title shown in the body template header, exposed as the {NewsletterTitle} tag.
+    /// </summary>
+    public string NewsletterTitle { get; set; } = "Jellyfin Newsletter";
+
+    /// <summary>
     /// Gets or sets a custom body HTML string. If empty, uses the template.
     /// </summary>
     public string Body { get; set; } = string.Empty;

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -1284,6 +1284,7 @@
                     ToAddr: '',
                     FromAddr: 'JellyfinNewsletter@donotreply.com',
                     Subject: 'Jellyfin Newsletter',
+                    NewsletterTitle: 'Jellyfin Newsletter',
                     Body: '',
                     Entry: '',
                     Header: '',
@@ -1351,6 +1352,7 @@
                 config.ToAddr = document.getElementById('email-bcc-' + id).value;
                 config.FromAddr = document.getElementById('email-from-' + id).value;
                 config.Subject = document.getElementById('email-subject-' + id).value;
+                config.NewsletterTitle = document.getElementById('email-title-' + id).value;
                 config.Body = document.getElementById('email-body-' + id).value;
                 config.Entry = document.getElementById('email-entry-' + id).value;
                 config.Header = document.getElementById('email-header-' + id).value;
@@ -1460,6 +1462,11 @@
                     html += '      <label class="inputLabel inputLabelUnfocused">Subject:</label>';
                     html += '      <input id="email-subject-' + config.Id + '" type="text" is="emby-input" value="' + (config.Subject || '') + '" onchange="updateEmailConfigFromUI(\'' + config.Id + '\')" />';
                     html += '    </div>';
+                    html += '    <div class="inputContainer">';
+                    html += '      <label class="inputLabel inputLabelUnfocused">Newsletter Title:</label>';
+                    html += '      <input id="email-title-' + config.Id + '" type="text" is="emby-input" value="' + (config.NewsletterTitle || 'Jellyfin Newsletter') + '" onchange="updateEmailConfigFromUI(\'' + config.Id + '\')" />';
+                    html += '      <div class="fieldDescription">Heading shown at the top of the newsletter. Also available as the {NewsletterTitle} tag in the Body HTML.</div>';
+                    html += '    </div>';
                     html += getLibrarySelectionHtml(config.Id, 'email', config.SelectedSeriesLibraries, config.SelectedMoviesLibraries);
                     html += getEventTogglesHtml(config.Id, 'email', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled, config.NewsletterOnFeaturedEnabled);
                     html += getMaxItemsHtml(config.Id, 'email', config.MaxItemsPerSection);
@@ -1504,6 +1511,7 @@
                     AccessToken: '',
                     RoomId: '',
                     TemplateCategory: 'Matrix',
+                    NewsletterTitle: 'Jellyfin Newsletter',
                     Body: '',
                     Entry: '',
                     Header: '',
@@ -1561,6 +1569,7 @@
                 config.HomeserverUrl = document.getElementById('matrix-url-' + id).value;
                 config.AccessToken = document.getElementById('matrix-token-' + id).value;
                 config.RoomId = document.getElementById('matrix-room-' + id).value;
+                config.NewsletterTitle = document.getElementById('matrix-title-' + id).value;
                 config.Body = document.getElementById('matrix-body-' + id).value;
                 config.Entry = document.getElementById('matrix-entry-' + id).value;
                 config.Header = document.getElementById('matrix-header-' + id).value;
@@ -1625,6 +1634,11 @@
                     html += '      <label class="inputLabel inputLabelUnfocused">Room ID:</label>';
                     html += '      <input id="matrix-room-' + config.Id + '" type="text" is="emby-input" value="' + (config.RoomId || '') + '" onchange="updateMatrixConfigFromUI(\'' + config.Id + '\')" />';
                     html += '      <div class="fieldDescription">The internal room ID (e.g., !yourRoomId:example.com). Separate multiple with commas.</div>';
+                    html += '    </div>';
+                    html += '    <div class="inputContainer">';
+                    html += '      <label class="inputLabel inputLabelUnfocused">Newsletter Title:</label>';
+                    html += '      <input id="matrix-title-' + config.Id + '" type="text" is="emby-input" value="' + (config.NewsletterTitle || 'Jellyfin Newsletter') + '" onchange="updateMatrixConfigFromUI(\'' + config.Id + '\')" />';
+                    html += '      <div class="fieldDescription">Heading shown at the top of the newsletter. Also available as the {NewsletterTitle} tag in the Body HTML.</div>';
                     html += '    </div>';
                     html += getLibrarySelectionHtml(config.Id, 'matrix', config.SelectedSeriesLibraries, config.SelectedMoviesLibraries);
                     html += getEventTogglesHtml(config.Id, 'matrix', config.NewsletterOnItemAddedEnabled, config.NewsletterOnItemUpdatedEnabled, config.NewsletterOnItemDeletedEnabled, config.NewsletterOnUpcomingItemEnabled, config.NewsletterOnFeaturedEnabled);

--- a/Jellyfin.Plugin.Newsletters/Templates/Classic/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Classic/template_body.html
@@ -11,7 +11,7 @@
 							<td colspan="2">
 								<h1 id="Title" style="font-size:3.3em;margin:10px 0 0 0;">
 									<a href="{ServerURL}" target="_blank" style="color:#E197BC;text-decoration: none;">
-										Jellyfin Newsletter
+										{NewsletterTitle}
 									</a>
 								</h1>
 								<h3 id="Date" style="color:#FFFFFF;margin:0px;">{prevd} {prevmon} {prevyyyy} - {d} {mon}

--- a/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Matrix/template_body.html
@@ -1,5 +1,5 @@
 <h1>
-    <a href="{ServerURL}" target="_blank">Jellyfin Newsletter</a>
+    <a href="{ServerURL}" target="_blank">{NewsletterTitle}</a>
 </h1>
 <small>
     <font data-mx-color="#a0a0a0">{prevd} {prevmon} {prevyyyy} - {d} {mon} {yyyy}</font>

--- a/Jellyfin.Plugin.Newsletters/Templates/Modern/template_body.html
+++ b/Jellyfin.Plugin.Newsletters/Templates/Modern/template_body.html
@@ -4,7 +4,7 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>Jellyfin Newsletter</title>
+	<title>{NewsletterTitle}</title>
 	<style>
 		body {
 			margin: 0;
@@ -220,7 +220,7 @@
 				<td class="header">
 					<h1>
 						<a href="{ServerURL}" target="_blank" style="color:#ffffff; text-decoration:none;">
-							Jellyfin Newsletter
+							{NewsletterTitle}
 						</a>
 					</h1>
 					<div class="header-date">{prevd} {prevmon} {prevyyyy} - {d} {mon} {yyyy}</div>

--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ Manifest is up and running! You can now import the manifest in Jellyfin and this
 
 - The subject of the email
 
+### Newsletter Title
+
+- The heading shown at the top of the newsletter body
+  - Defaults to `Jellyfin Newsletter`
+  - Also available as the `{NewsletterTitle}` tag in the Body HTML
+
 ### Smtp Server Address
 
 - The email server address you want to use.
@@ -435,6 +441,12 @@ You can select between different email templates:
 
 - The Room ID where newsletters will be sent (e.g., `!roomid:matrix.org`). You can find this in your Matrix client's room settings. **Supports multiple Room IDs**: You can enter multiple Room IDs separated by commas `,`.
 
+### Newsletter Title
+
+- The heading shown at the top of the newsletter body
+  - Defaults to `Jellyfin Newsletter`
+  - Also available as the `{NewsletterTitle}` tag in the Body HTML
+
 ### Test Message
 
 - Use the "Test" button to send a test message and verify your Matrix configuration before saving.
@@ -581,6 +593,7 @@ newsletter onwards.
 
 ```
 - {ServerURL} - The configured server URL for Jellyfin
+- {NewsletterTitle} - The configured per-client newsletter title - used in the Body template header
 - {SeasonEpsInfo} - This tag is the Plugin-generated Season/Episode data
 - {Title} - Title of Movie/Series
 - {SeriesOverview} - Movie/Series overview


### PR DESCRIPTION
## What

Closes #124

The email **subject** is configurable per Email configuration, but the title rendered at the top of every newsletter was the hardcoded string `Jellyfin Newsletter`, baked into each `template_body.html`. This adds a **Newsletter Title** field to each Email and Matrix configuration (same granularity as `Subject`), surfaced as a new `{NewsletterTitle}` template tag. The default is `Jellyfin Newsletter`, so existing installs render exactly as before.

## Changes

- **Config model** — `NewsletterTitle` added to `ITemplatedConfiguration`, `EmailConfiguration`, and `MatrixConfiguration` (default `"Jellyfin Newsletter"`).
- **Substitution** — one `{NewsletterTitle}` replacement in `HtmlContentBuilder.ReplaceBodyPlaceholders`, next to `{ServerURL}` — the single body-level tag method every render path (email/matrix, send/test) already calls.
- **Templates** — `Jellyfin Newsletter` → `{NewsletterTitle}` in the Modern (`<title>` + `<h1>`), Classic, and Matrix `template_body.html`.
- **Matrix plaintext fallback** — uses the configured title instead of the literal.
- **Config UI** — "Newsletter Title" input added to each Email and Matrix configuration block (below Subject for Email), wired through add/update/render.
- **Docs** — `README.md` config sections for Email and Matrix, plus `{NewsletterTitle}` in the tag reference.

Property name, JSON round-trip key, and template tag all use `NewsletterTitle` (the tag can't be `{Title}` — that's already the per-item movie/series title).

## Testing

- `dotnet build` — clean, 0 warnings / 0 errors.
- No `Jellyfin Newsletter` literal remains in `Templates/`.
- Manual: set a custom title on an Email config, send a test → email `<h1>` and tab title show the custom value; untouched configs still render `Jellyfin Newsletter`. Same for Matrix.

## Out of scope

Version bumps (`build.yaml`, `Directory.Build.props`, `manifest.json`) and `CHANGELOG.md` — handled in the separate release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)